### PR TITLE
Support building against multiple Nix versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ path (path info queries, bulk import, NAR download).
     nix build
 
 This produces `result/bin/nix-grpc-daemon` for the server and
-`result/lib/nix/plugins/nix-grpc-store.so` for the client.
+`result/lib/nix/plugins/nix-grpc-store-loader.so` for the client, which
+dispatches to the plugin build matching the running Nix version.
 
 ## Quick start (NixOS)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nix-grpc-store
 
-**Status: Beta.** Interfaces may change. Plugin ABI is tied to a specific Nix version.
+**Status: Beta.** Interfaces may change.
 
 Remote Nix store access over gRPC instead of SSH.
 
@@ -49,10 +49,11 @@ Add the flake and enable the modules:
     imports = [ nix-grpc-store.nixosModules.client ];
     programs.nix-grpc-store.enable = true;
 
-The client module builds the plugin against `config.nix.package.libs`, so it
-tracks whatever Nix your system uses. The server module runs the daemon as an
-unprivileged `nix-grpc-daemon` user and adds it to `extra-allowed-users` so it
-can reach the local `nix-daemon` even when `allowed-users` is restricted.
+The client module ships plugin builds for the supported Nix versions and a
+loader that picks the one matching the running Nix. The server module runs
+the daemon as an unprivileged `nix-grpc-daemon` user and adds it to
+`extra-allowed-users` so it can reach the local `nix-daemon` even when
+`allowed-users` is restricted.
 
 ## Trust model
 
@@ -76,8 +77,8 @@ client then has trusted-user privileges, so require client certs
       maxJobs = 64;
     }];
 
-Only the nix-daemon needs the plugin loaded. TLS uses the system CA bundle
-and the client key pair from `/run/nix-grpc-store` by default (see below).
+TLS uses the system CA bundle and the client key pair from
+`/run/nix-grpc-store` by default (see below).
 
 ## Quick start (manual)
 
@@ -87,7 +88,7 @@ On the builder:
 
 On the client, add to `nix.conf`:
 
-    plugin-files = /path/to/nix-grpc-store.so
+    plugin-files = /path/to/lib/nix/plugins
 
 and use it like any other store URI:
 

--- a/checks.nix
+++ b/checks.nix
@@ -1,0 +1,33 @@
+{
+  pkgs,
+  packages,
+  nixPackages,
+  nixosModule,
+}:
+let
+  inherit (pkgs) lib;
+in
+# Every per-version plugin package doubles as a compile check.
+lib.filterAttrs (name: _: lib.hasPrefix "plugin-" name) packages
+// {
+  clang-tidy = packages.default.overrideAttrs (old: {
+    pname = "nix-grpc-store-clang-tidy";
+    nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.llvmPackages_latest.clang-tools ];
+    # Meson generates a clang-tidy target from .clang-tidy. The generated
+    # protobuf headers must exist before it runs.
+    buildPhase = ''
+      ninja nix_remote.pb.h nix_remote.grpc.pb.h
+      ninja clang-tidy
+    '';
+    installPhase = "touch $out";
+    doCheck = false;
+    dontFixup = true;
+  });
+}
+// lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  vm = import ./tests/nixos-test.nix {
+    inherit pkgs;
+    nixPkgs = nixPackages;
+    module = nixosModule;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,16 @@
       nix,
     }:
     let
-      forAllSystems = nixpkgs.lib.genAttrs [
+      lib = nixpkgs.lib;
+      # Nix versions from nixpkgs that expose split component libraries
+      # (`.libs.nix-store`, `.libs.nix-util`) which the plugin builds against.
+      supportedNixVersions = [
+        "nix_2_31"
+        "nix_2_34"
+        "nix_2_35"
+        "git"
+      ];
+      forAllSystems = lib.genAttrs [
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
@@ -31,6 +40,18 @@
             inherit (nix.packages.${system}) nix-store nix-util;
           };
         }
+        # One plugin per supported Nix version; the plugin is ABI-coupled to
+        # the Nix that dlopen()s it.
+        // lib.listToAttrs (
+          map (
+            version:
+            lib.nameValuePair "plugin-${version}" (
+              pkgs.callPackage ./package.nix {
+                inherit (pkgs.nixVersions.${version}.libs) nix-store nix-util;
+              }
+            )
+          ) supportedNixVersions
+        )
       );
 
       nixosModules = {
@@ -47,7 +68,9 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
         in
-        {
+        # Every per-version plugin package doubles as a compile check.
+        lib.filterAttrs (name: _: lib.hasPrefix "plugin-" name) self.packages.${system}
+        // {
           clang-tidy = self.packages.${system}.default.overrideAttrs (old: {
             pname = "nix-grpc-store-clang-tidy";
             nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.llvmPackages_latest.clang-tools ];
@@ -62,7 +85,7 @@
             dontFixup = true;
           });
         }
-        // nixpkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+        // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
           vm = import ./tests/nixos-test.nix {
             inherit pkgs;
             nixPkgs = nix.packages.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -15,14 +15,6 @@
     }:
     let
       lib = nixpkgs.lib;
-      # Nix versions from nixpkgs that expose split component libraries
-      # (`.libs.nix-store`, `.libs.nix-util`) which the plugin builds against.
-      supportedNixVersions = [
-        "nix_2_31"
-        "nix_2_34"
-        "nix_2_35"
-        "git"
-      ];
       forAllSystems = lib.genAttrs [
         "x86_64-linux"
         "aarch64-linux"
@@ -33,25 +25,14 @@
       packages = forAllSystems (
         system:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          scope = nixpkgs.legacyPackages.${system}.callPackage ./packages.nix {
+            nixPackages = nix.packages.${system};
+          };
         in
         {
-          default = pkgs.callPackage ./package.nix {
-            inherit (nix.packages.${system}) nix-store nix-util;
-          };
+          inherit (scope) default plugin-dispatcher;
         }
-        # One plugin per supported Nix version; the plugin is ABI-coupled to
-        # the Nix that dlopen()s it.
-        // lib.listToAttrs (
-          map (
-            version:
-            lib.nameValuePair "plugin-${version}" (
-              pkgs.callPackage ./package.nix {
-                inherit (pkgs.nixVersions.${version}.libs) nix-store nix-util;
-              }
-            )
-          ) supportedNixVersions
-        )
+        // scope.versionPlugins
       );
 
       nixosModules = {
@@ -65,32 +46,11 @@
 
       checks = forAllSystems (
         system:
-        let
+        import ./checks.nix {
           pkgs = nixpkgs.legacyPackages.${system};
-        in
-        # Every per-version plugin package doubles as a compile check.
-        lib.filterAttrs (name: _: lib.hasPrefix "plugin-" name) self.packages.${system}
-        // {
-          clang-tidy = self.packages.${system}.default.overrideAttrs (old: {
-            pname = "nix-grpc-store-clang-tidy";
-            nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.llvmPackages_latest.clang-tools ];
-            # Meson generates a clang-tidy target from .clang-tidy; the
-            # generated protobuf headers must exist before it runs.
-            buildPhase = ''
-              ninja nix_remote.pb.h nix_remote.grpc.pb.h
-              ninja clang-tidy
-            '';
-            installPhase = "touch $out";
-            doCheck = false;
-            dontFixup = true;
-          });
-        }
-        // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-          vm = import ./tests/nixos-test.nix {
-            inherit pkgs;
-            nixPkgs = nix.packages.${system};
-            module = self.nixosModules.default;
-          };
+          packages = self.packages.${system};
+          nixPackages = nix.packages.${system};
+          nixosModule = self.nixosModules.default;
         }
       );
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,11 @@
     }:
     let
       lib = nixpkgs.lib;
+      packageSetFor =
+        pkgs:
+        pkgs.callPackage ./packages.nix {
+          nixPackages = nix.packages.${pkgs.stdenv.hostPlatform.system};
+        };
       forAllSystems = lib.genAttrs [
         "x86_64-linux"
         "aarch64-linux"
@@ -25,9 +30,7 @@
       packages = forAllSystems (
         system:
         let
-          scope = nixpkgs.legacyPackages.${system}.callPackage ./packages.nix {
-            nixPackages = nix.packages.${system};
-          };
+          scope = packageSetFor nixpkgs.legacyPackages.${system};
         in
         {
           inherit (scope) default plugin-dispatcher;
@@ -37,7 +40,14 @@
 
       nixosModules = {
         server = ./nixos/server.nix;
-        client = ./nixos/client.nix;
+        # Reuse the flake's package set so hosts get the same derivations as
+        # `nix build` instead of rebuilding the plugins per machine.
+        client =
+          { pkgs, ... }:
+          {
+            imports = [ ./nixos/client.nix ];
+            programs.nix-grpc-store.packageSet = lib.mkDefault (packageSetFor pkgs);
+          };
         default.imports = [
           self.nixosModules.server
           self.nixosModules.client

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,15 @@ threads_dep  = dependency('threads')
 nix_store_dep = dependency('nix-store')
 nix_util_dep  = dependency('nix-util')
 
+# Version macros for src/nix-compat.hh; see that header for the differences
+# between supported Nix versions.
+nix_ver = nix_store_dep.version().split('.')
+nix_compat_args = [
+  '-DNIX_COMPAT_VERSION_MAJOR=' + nix_ver[0],
+  # Pre-release versions look like "2.35pre20260619_f8bb823a".
+  '-DNIX_COMPAT_VERSION_MINOR=' + nix_ver[1].split('pre')[0],
+]
+
 # --- protobuf / gRPC codegen -----------------------------------------------
 
 protoc          = find_program('protoc')
@@ -48,6 +57,7 @@ pump_deps = [grpc_dep, protobuf_dep, zstd_dep, threads_dep, nix_util_dep]
 shared_module('nix-grpc-store',
   sources : ['src/grpc-store.cc', gen],
   include_directories : gen_inc,
+  cpp_args : nix_compat_args,
   dependencies : pump_deps + [nix_store_dep],
   name_prefix : '',
   install : true,
@@ -59,6 +69,7 @@ shared_module('nix-grpc-store',
 executable('nix-grpc-daemon',
   sources : ['src/nix-grpc-daemon.cc', gen],
   include_directories : gen_inc,
+  cpp_args : nix_compat_args,
   # nix-store: native QueryValidPaths / AddMultipleToStore handlers.
   dependencies : pump_deps + [nix_store_dep],
   install : true,

--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,9 @@ pump_deps = [grpc_dep, protobuf_dep, zstd_dep, threads_dep, nix_util_dep]
 shared_module('nix-grpc-store',
   sources : ['src/grpc-store.cc', gen],
   include_directories : gen_inc,
-  cpp_args : nix_compat_args,
+  # nix_plugin_entry() skips registering the store when the running Nix
+  # version differs from the one the plugin was built against.
+  cpp_args : nix_compat_args + ['-DNIX_GRPC_BUILT_AGAINST_NIX="' + nix_store_dep.version() + '"'],
   dependencies : pump_deps + [nix_store_dep],
   name_prefix : '',
   install : true,

--- a/meson.build
+++ b/meson.build
@@ -49,9 +49,21 @@ gen = custom_target('nix_remote_proto',
 
 gen_inc = include_directories('.')
 
-pump_deps = [grpc_dep, protobuf_dep, zstd_dep, threads_dep, nix_util_dep]
+common_deps = [grpc_dep, protobuf_dep, zstd_dep, threads_dep]
 
 # --- client plugin ----------------------------------------------------------
+
+# Compile against the Nix headers only. The symbols resolve at dlopen() time
+# from the host `nix` process, avoiding a second copy of the Nix libraries.
+nix_header_deps = [
+  nix_store_dep.partial_dependency(compile_args : true, includes : true),
+  nix_util_dep.partial_dependency(compile_args : true, includes : true),
+]
+if host_machine.system() == 'darwin'
+  plugin_link_args = ['-Wl,-undefined,dynamic_lookup']
+else
+  plugin_link_args = ['-Wl,--unresolved-symbols=ignore-all']
+endif
 
 # Built as a shared module so it can be loaded via nix.conf `plugin-files`.
 shared_module('nix-grpc-store',
@@ -60,7 +72,8 @@ shared_module('nix-grpc-store',
   # nix_plugin_entry() skips registering the store when the running Nix
   # version differs from the one the plugin was built against.
   cpp_args : nix_compat_args + ['-DNIX_GRPC_BUILT_AGAINST_NIX="' + nix_store_dep.version() + '"'],
-  dependencies : pump_deps + [nix_store_dep],
+  dependencies : common_deps + nix_header_deps,
+  link_args : plugin_link_args,
   name_prefix : '',
   install : true,
   install_dir : get_option('libdir') / 'nix' / 'plugins',
@@ -73,6 +86,6 @@ executable('nix-grpc-daemon',
   include_directories : gen_inc,
   cpp_args : nix_compat_args,
   # nix-store: native QueryValidPaths / AddMultipleToStore handlers.
-  dependencies : pump_deps + [nix_store_dep],
+  dependencies : common_deps + [nix_util_dep, nix_store_dep],
   install : true,
 )

--- a/meson.build
+++ b/meson.build
@@ -13,13 +13,15 @@ threads_dep  = dependency('threads')
 nix_store_dep = dependency('nix-store')
 nix_util_dep  = dependency('nix-util')
 
-# Version macros for src/nix-compat.hh; see that header for the differences
-# between supported Nix versions.
+# Pre-release versions look like "2.35pre20260619_f8bb823a".
 nix_ver = nix_store_dep.version().split('.')
+nix_ver_minor = nix_ver[1].split('pre')[0]
+nix_ver_major_minor = nix_ver[0] + '.' + nix_ver_minor
+
+# Version macros for src/nix-compat.hh.
 nix_compat_args = [
   '-DNIX_COMPAT_VERSION_MAJOR=' + nix_ver[0],
-  # Pre-release versions look like "2.35pre20260619_f8bb823a".
-  '-DNIX_COMPAT_VERSION_MINOR=' + nix_ver[1].split('pre')[0],
+  '-DNIX_COMPAT_VERSION_MINOR=' + nix_ver_minor,
 ]
 
 # --- protobuf / gRPC codegen -----------------------------------------------
@@ -65,7 +67,6 @@ else
   plugin_link_args = ['-Wl,--unresolved-symbols=ignore-all']
 endif
 
-# Built as a shared module so it can be loaded via nix.conf `plugin-files`.
 shared_module('nix-grpc-store',
   sources : ['src/grpc-store.cc', gen],
   include_directories : gen_inc,
@@ -73,6 +74,18 @@ shared_module('nix-grpc-store',
   # version differs from the one the plugin was built against.
   cpp_args : nix_compat_args + ['-DNIX_GRPC_BUILT_AGAINST_NIX="' + nix_store_dep.version() + '"'],
   dependencies : common_deps + nix_header_deps,
+  link_args : plugin_link_args,
+  name_prefix : '',
+  install : true,
+  install_dir : get_option('libdir') / 'nix' / 'nix-grpc-store-versions' / nix_ver_major_minor,
+)
+
+# Loaded via nix.conf `plugin-files`. It dlopen()s the build matching the
+# running Nix from the versions directory above, so merged installs of
+# several builds support all of their Nix versions.
+shared_module('nix-grpc-store-loader',
+  sources : ['src/plugin-loader.cc'],
+  dependencies : dependency('dl'),
   link_args : plugin_link_args,
   name_prefix : '',
   install : true,

--- a/nixos/client.nix
+++ b/nixos/client.nix
@@ -24,7 +24,7 @@ in
           inherit (config.nix.package.libs) nix-store nix-util;
         }
       '';
-      description = "Package providing `lib/nix/plugins/nix-grpc-store.so`.";
+      description = "Package providing the plugin loader under `lib/nix/plugins`.";
     };
   };
 

--- a/nixos/client.nix
+++ b/nixos/client.nix
@@ -12,27 +12,28 @@ in
   options.programs.nix-grpc-store = {
     enable = lib.mkEnableOption "the grpc:// Nix store plugin";
 
-    package = lib.mkOption {
-      type = lib.types.package;
-      # Build against the component libraries of the system's Nix so the
-      # plugin's C++ ABI matches the `nix` binary that will dlopen() it.
-      default = pkgs.callPackage ../package.nix {
-        inherit (config.nix.package.libs) nix-store nix-util;
+    packageSet = lib.mkOption {
+      type = lib.types.raw;
+      default = pkgs.callPackage ../packages.nix {
+        nixPackages = config.nix.package.libs;
       };
       defaultText = lib.literalExpression ''
-        pkgs.callPackage ./package.nix {
-          inherit (config.nix.package.libs) nix-store nix-util;
-        }
+        pkgs.callPackage ./packages.nix { nixPackages = config.nix.package.libs; }
       '';
+      description = "Package set from packages.nix providing the per-version plugins.";
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = cfg.packageSet.plugin-dispatcher;
+      defaultText = lib.literalExpression "config.programs.nix-grpc-store.packageSet.plugin-dispatcher";
       description = "Package providing the plugin loader under `lib/nix/plugins`.";
     };
   };
 
   config = lib.mkIf cfg.enable {
-    # Only the daemon loads the plugin; via global nix.conf every other nix
-    # binary on the system would dlopen an ABI-incompatible plugin and crash.
-    systemd.services.nix-daemon.environment.NIX_CONFIG = ''
-      plugin-files = ${cfg.package}/lib/nix/plugins
-    '';
+    # The loader warns and disables grpc:// stores on a version mismatch
+    # instead of crashing, so it is safe to load in every nix invocation.
+    nix.settings.plugin-files = [ "${cfg.package}/lib/nix/plugins" ];
   };
 }

--- a/packages.nix
+++ b/packages.nix
@@ -1,0 +1,49 @@
+# Package set with one plugin per supported Nix version plus the dispatcher
+# bundle.
+{
+  lib,
+  newScope,
+  nixVersions,
+  symlinkJoin,
+  # Nix package set the default plugin builds against.
+  nixPackages,
+}:
+lib.makeScope newScope (
+  self:
+  let
+    # Nix releases from nixpkgs that ship split component libraries.
+    supportedNixVersions = builtins.filter (
+      name:
+      builtins.match "nix_[0-9]+_[0-9]+" name != null
+      && (builtins.tryEval (nixVersions.${name}.libs ? nix-store)).value or false
+    ) (builtins.attrNames nixVersions);
+  in
+  {
+    default = self.callPackage ./package.nix {
+      inherit (nixPackages) nix-store nix-util;
+    };
+
+    # One plugin per supported Nix version. "git" is only a compile check for
+    # the next release.
+    versionPlugins = lib.listToAttrs (
+      map (
+        version:
+        lib.nameValuePair "plugin-${version}" (
+          self.callPackage ./package.nix {
+            inherit (nixVersions.${version}.libs) nix-store nix-util;
+          }
+        )
+      ) (supportedNixVersions ++ [ "git" ])
+    );
+
+    # Merged per-version builds. The loader picks the one matching the
+    # running Nix, see meson.build.
+    plugin-dispatcher = symlinkJoin {
+      name = "nix-grpc-store-dispatcher";
+      paths = [
+        self.default
+      ]
+      ++ map (version: self.versionPlugins."plugin-${version}") supportedNixVersions;
+    };
+  }
+)

--- a/packages.nix
+++ b/packages.nix
@@ -1,5 +1,4 @@
-# Package set with one plugin per supported Nix version plus the dispatcher
-# bundle.
+# Package set with one plugin per supported Nix version plus the dispatcher bundle.
 {
   lib,
   newScope,
@@ -23,8 +22,8 @@ lib.makeScope newScope (
       inherit (nixPackages) nix-store nix-util;
     };
 
-    # One plugin per supported Nix version. "git" is only a compile check for
-    # the next release.
+    # One plugin per supported Nix version.
+    # "git" is only a compile check for the next release.
     versionPlugins = lib.listToAttrs (
       map (
         version:
@@ -36,14 +35,14 @@ lib.makeScope newScope (
       ) (supportedNixVersions ++ [ "git" ])
     );
 
-    # Merged per-version builds. The loader picks the one matching the
-    # running Nix, see meson.build.
+    # The loader picks the one matching the running Nix, see meson.build.
     plugin-dispatcher = symlinkJoin {
       name = "nix-grpc-store-dispatcher";
       paths = [
         self.default
       ]
       ++ map (version: self.versionPlugins."plugin-${version}") supportedNixVersions;
+      meta.mainProgram = "nix-grpc-daemon";
     };
   }
 )

--- a/src/grpc-store.cc
+++ b/src/grpc-store.cc
@@ -49,6 +49,7 @@
 #include <nix/util/url.hh>
 #include <utility>
 
+#include "nix-compat.hh"
 #include "nix_remote.grpc.pb.h"
 #include "nix_remote.pb.h"
 #include "pump.hh"
@@ -135,14 +136,23 @@ private:
 
 public:
     GrpcStoreConfig(const Params & params)
-        : StoreConfig(params, FilePathType::Unix)
-        , RemoteStoreConfig(params, FilePathType::Unix)
+        : StoreConfig(NIX_COMPAT_STORE_CONFIG_ARGS(params))
+        , RemoteStoreConfig(NIX_COMPAT_STORE_CONFIG_ARGS(params))
     {
     }
 
+#if !NIX_COMPAT_AT_LEAST(2, 34)
+    // Nix < 2.34 constructs store configs from the raw scheme and authority
+    // strings instead of a pre-parsed ParsedURL::Authority.
+    GrpcStoreConfig(std::string_view /*scheme*/, std::string_view authority, const Params &params)
+        : StoreConfig(params),
+          RemoteStoreConfig(params),
+          authority(ParsedURL::Authority::parse(authority)) {}
+#endif
+
     GrpcStoreConfig(ParsedURL::Authority authority, const Params &params)
-        : StoreConfig(params, FilePathType::Unix),
-          RemoteStoreConfig(params, FilePathType::Unix),
+        : StoreConfig(NIX_COMPAT_STORE_CONFIG_ARGS(params)),
+          RemoteStoreConfig(NIX_COMPAT_STORE_CONFIG_ARGS(params)),
           authority(std::move(authority)) {}
 
     static auto name() -> std::string { return "gRPC Store"; }
@@ -225,10 +235,6 @@ public:
     }
 
 private:
-    /* ValidPathInfo serialisation used by the bulk RPCs, matching the worker
-       protocol's AddMultipleToStore framing. */
-    static constexpr WorkerProto::Version::Number infoVersion{.major = 1, .minor = 16};
-
     /* Whether the server implements the native (non-tunnelled) RPCs. Probed
        once with an empty QueryValidPaths so bulk operations can decide
        between the native path and the tunnel before consuming any data. */
@@ -307,7 +313,7 @@ private:
         StringSource source(entry.info());
         auto info = WorkerProto::Serialise<UnkeyedValidPathInfo>::read(
             *this, WorkerProto::ReadConn{.from = source,
-                                         .version = {.number = infoVersion}});
+                                         .version = nixcompat::infoProtocolVersion()});
         res.insert_or_assign(path, std::make_shared<ValidPathInfo>(
                                        StorePath(path), std::move(info)));
       }
@@ -315,6 +321,9 @@ private:
     }
 
 public:
+// topoSortPaths() only became virtual in Nix 2.35; without the hook, `nix
+// copy` falls back to one QueryPathInfos RPC per path.
+#if NIX_COMPAT_AT_LEAST(2, 35)
     auto topoSortPaths(const StorePathSet &paths) -> StorePaths override {
       // copyPaths() hands the source store the full set of paths to copy
       // here, right before querying their info one by one; prefetch them in
@@ -326,6 +335,7 @@ public:
       }
       return Store::topoSortPaths(paths);
     }
+#endif
 
     void queryPathInfoUncached(
         const StorePath & path, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override
@@ -481,7 +491,7 @@ public:
                     nrTotal - pathsToCopy.size(), nrTotal, static_cast<size_t>(1), static_cast<size_t>(0));
                 auto & [pathInfo, pathSource] = pathsToCopy.back();
                 WorkerProto::Serialise<ValidPathInfo>::write(
-                    *this, WorkerProto::WriteConn{.to = sink, .version = {.number = infoVersion}}, pathInfo);
+                    *this, WorkerProto::WriteConn{.to = sink, .version = nixcompat::infoProtocolVersion()}, pathInfo);
                 pathSource->drainInto(sink);
                 pathsToCopy.pop_back();
             }

--- a/src/grpc-store.cc
+++ b/src/grpc-store.cc
@@ -18,6 +18,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <nix/store/globals.hh>
 #include <nix/store/path.hh>
 #include <nix/store/store-api.hh>
 #include <nix/store/store-reference.hh>
@@ -32,6 +33,7 @@
 #include <nix/util/util.hh>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unistd.h>
 #include <vector>
@@ -614,11 +616,30 @@ auto GrpcStoreConfig::openStore() const -> ref<Store> {
   return make_ref<GrpcStore>(ref{shared_from_this()});
 }
 
+} // namespace nix
+
 namespace {
-// Store registration is inherently a non-const global whose constructor may
-// allocate; this is the standard Nix plugin pattern.
-// NOLINTNEXTLINE(cert-err58-cpp,cppcoreguidelines-avoid-non-const-global-variables,bugprone-throwing-static-initialization)
-RegisterStoreImplementation<GrpcStoreConfig> regGrpcStore;
+
+// "2.31.5" / "2.35pre20260619_f8bb823a" -> "2.31" / "2.35"
+auto majorMinor(std::string_view version) -> std::string_view {
+  auto firstDot = version.find('.');
+  auto end = version.find_first_not_of("0123456789", firstDot + 1);
+  return version.substr(0, end);
+}
+
 } // namespace
 
-} // namespace nix
+// Called by Nix right after dlopen(). Registering here instead of in a static
+// initializer lets a version mismatch degrade to a warning.
+extern "C" void nix_plugin_entry() {
+  auto running = majorMinor(nix::nixVersion);
+  auto builtAgainst = majorMinor(NIX_GRPC_BUILT_AGAINST_NIX);
+  if (running != builtAgainst) {
+    nix::warn(
+        "nix-grpc-store plugin was built against Nix %s but is being loaded by Nix %s. "
+        "grpc:// stores are unavailable",
+        std::string(builtAgainst), std::string(running));
+    return;
+  }
+  static const nix::RegisterStoreImplementation<nix::GrpcStoreConfig> regGrpcStore;
+}

--- a/src/nix-compat.hh
+++ b/src/nix-compat.hh
@@ -1,0 +1,68 @@
+#pragma once
+// Compatibility helpers for building against multiple Nix versions.
+// NIX_COMPAT_VERSION_{MAJOR,MINOR} come from meson (version of the
+// `nix-store` pkg-config dependency).
+
+#include <concepts>
+#include <cstdint>
+
+#include <nix/store/worker-protocol.hh>
+#include <nix/util/serialise.hh>
+
+// Must be a macro: it is evaluated in #if directives below and in the sources.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define NIX_COMPAT_AT_LEAST(major, minor)                                     \
+  (NIX_COMPAT_VERSION_MAJOR > (major) ||                                      \
+   (NIX_COMPAT_VERSION_MAJOR == (major) && NIX_COMPAT_VERSION_MINOR >= (minor)))
+
+// Nix 2.35 added a FilePathType argument to the StoreConfig /
+// RemoteStoreConfig constructors.
+// Must be a macro: it expands inside constructor member-initializer lists.
+#if NIX_COMPAT_AT_LEAST(2, 35)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define NIX_COMPAT_STORE_CONFIG_ARGS(params) params, FilePathType::Unix
+#else
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define NIX_COMPAT_STORE_CONFIG_ARGS(params) params
+#endif
+
+namespace nixcompat {
+
+// Nix 2.34 turned WorkerProto::Version from a packed unsigned int into a
+// struct; detect the representation instead of checking version numbers.
+template <typename V = nix::WorkerProto::Version>
+constexpr auto makeProtocolVersion(unsigned int major, uint8_t minor) -> V {
+  if constexpr (std::integral<V>) {
+    constexpr unsigned int minorBits = 8; // wire format: (major << 8) | minor
+    return (major << minorBits) | minor;
+  } else {
+    return V{.number = {.major = major, .minor = minor}};
+  }
+}
+
+// Worker-protocol version 1.16: the ValidPathInfo framing used by the bulk
+// RPCs.
+inline auto infoProtocolVersion() -> nix::WorkerProto::Version {
+  constexpr unsigned int major = 1;
+  constexpr uint8_t minor = 16;
+  return makeProtocolVersion(major, minor);
+}
+
+// Nix 2.35 added EnsureRead, which turns a short NAR read into an error
+// instead of silently truncating. Older versions read the NAR unguarded.
+#if NIX_COMPAT_AT_LEAST(2, 35)
+using EnsureRead = nix::EnsureRead;
+#else
+class EnsureRead : public nix::Source {
+  nix::Source &inner;
+
+public:
+  EnsureRead(nix::Source &source, uint64_t /*bytesExpected*/) : inner(source) {}
+  auto read(char *data, size_t len) -> size_t override {
+    return inner.read(data, len);
+  }
+  void finish() {}
+};
+#endif
+
+} // namespace nixcompat

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -47,6 +47,7 @@
 #include <nix/util/unix-domain-socket.hh>
 #include <nix/util/util.hh>
 
+#include "nix-compat.hh"
 #include "nix_remote.grpc.pb.h"
 #include "nix_remote.pb.h"
 #include "pump.hh"
@@ -59,10 +60,6 @@ namespace {
 
 class NixRemoteService final : public nix::remote::NixRemote::Service
 {
-    /* nix::ValidPathInfo serialisation used by the bulk RPCs, matching the worker
-       protocol's AddMultipleToStore framing. */
-    static constexpr nix::WorkerProto::Version::Number infoVersion{.major = 1, .minor = 16};
-
     std::string socketPath;
 
     std::mutex storeMutex;
@@ -167,9 +164,10 @@ public:
             auto expected = nix::readNum<uint64_t>(source);
             for (uint64_t idx = 0; idx < expected; ++idx) {
                 auto info = nix::WorkerProto::Serialise<nix::ValidPathInfo>::read(
-                    *localStore, nix::WorkerProto::ReadConn{.from = source, .version = {.number = infoVersion}});
+                    *localStore,
+                    nix::WorkerProto::ReadConn{.from = source, .version = nixcompat::infoProtocolVersion()});
                 info.ultimate = false;
-                nix::EnsureRead wrapper{source, info.narSize};
+                nixcompat::EnsureRead wrapper{source, info.narSize};
                 localStore->addToStore(info, wrapper, repair, checkSigs);
                 wrapper.finish();
             }
@@ -196,7 +194,7 @@ public:
                 nix::StringSink sink;
                 nix::WorkerProto::Serialise<nix::UnkeyedValidPathInfo>::write(
                     *localStore,
-                    nix::WorkerProto::WriteConn{.to = sink, .version = {.number = infoVersion}},
+                    nix::WorkerProto::WriteConn{.to = sink, .version = nixcompat::infoProtocolVersion()},
                     static_cast<const nix::UnkeyedValidPathInfo &>(*info));
                 *out->mutable_info() = std::move(sink.s);
             }

--- a/src/plugin-loader.cc
+++ b/src/plugin-loader.cc
@@ -1,0 +1,79 @@
+// Dispatcher plugin loaded via nix.conf `plugin-files`. It dlopen()s the
+// nix-grpc-store build matching the running Nix version from
+// ../nix-grpc-store-versions/<major.minor>/ next to itself. If no build
+// matches, it warns and leaves grpc:// stores unregistered.
+//
+// It must not use any Nix API beyond the version string.
+
+#include <cstdio>
+#include <cstdlib>
+#include <dlfcn.h>
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace nix {
+// Resolved from the host `nix` process at dlopen() time.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern std::string nixVersion;
+} // namespace nix
+
+namespace {
+
+// "2.31.5" / "2.35pre20260619_f8bb823a" -> "2.31" / "2.35"
+auto majorMinor(std::string_view version) -> std::string_view {
+  auto firstDot = version.find('.');
+  auto end = version.find_first_not_of("0123456789", firstDot + 1);
+  return version.substr(0, end);
+}
+
+// nix::warn() would drag in more of the Nix ABI, so use plain stderr.
+void warn(const std::string &message) {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+  static_cast<void>(std::fprintf(
+      stderr, "warning: nix-grpc-store: %s. grpc:// stores are unavailable\n",
+      message.c_str()));
+}
+
+// <this .so's directory>/../nix-grpc-store-versions/<major.minor>/nix-grpc-store.so
+auto pluginForRunningNix() -> std::filesystem::path {
+  Dl_info info{};
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): dladdr needs a data pointer
+  if (dladdr(reinterpret_cast<void *>(&pluginForRunningNix), &info) == 0 ||
+      info.dli_fname == nullptr) {
+    return {};
+  }
+  return std::filesystem::path(info.dli_fname).parent_path().parent_path() /
+         "nix-grpc-store-versions" / majorMinor(nix::nixVersion) /
+         "nix-grpc-store.so";
+}
+
+} // namespace
+
+extern "C" void nix_plugin_entry() {
+  std::filesystem::path plugin;
+  // NOLINTNEXTLINE(concurrency-mt-unsafe): plugins are loaded before Nix spawns threads
+  if (const char *override = std::getenv("NIX_GRPC_PLUGIN_OVERRIDE")) {
+    plugin = override;
+  } else {
+    plugin = pluginForRunningNix();
+  }
+
+  if (plugin.empty() || !std::filesystem::exists(plugin)) {
+    warn("no plugin build for Nix " + nix::nixVersion);
+    return;
+  }
+
+  // Leaked on purpose: the plugin stays registered for the process lifetime.
+  void *handle = dlopen(plugin.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (handle == nullptr) {
+    // NOLINTNEXTLINE(concurrency-mt-unsafe): plugins are loaded before Nix spawns threads
+    warn("could not load '" + plugin.string() + "': " + dlerror());
+    return;
+  }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): dlsym returns void*
+  auto entry = reinterpret_cast<void (*)()>(dlsym(handle, "nix_plugin_entry"));
+  if (entry != nullptr) {
+    entry();
+  }
+}

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -1,5 +1,5 @@
-# End-to-end test: run nix-grpc-daemon backed by the system nix-daemon, then
-# drive it from a Nix client that loads the plugin and speaks grpc://.
+# End-to-end test: run nix-grpc-daemon backed by the system nix-daemon,
+# then drive it from a Nix client that loads the plugin and speaks grpc://.
 #
 # Verifies the whole stack:
 #   nix CLI → plugin → gRPC → nix-grpc-daemon → unix:// nix-daemon → LocalStore
@@ -25,8 +25,7 @@ pkgs.testers.runNixOSTest {
       virtualisation.memorySize = 2048;
       virtualisation.cores = 2;
 
-      # The client module builds the plugin against `nix.package.libs`, so this
-      # must be a package that exposes them (nix-everything / nixpkgs' `nix`).
+      # Must be a Nix version the plugin bundle contains a build for.
       nix.package = nixPkgs.nix-everything;
       nix.settings = {
         experimental-features = [ "nix-command" ];
@@ -35,14 +34,10 @@ pkgs.testers.runNixOSTest {
       };
 
       programs.nix-grpc-store.enable = true;
-      # The client module only loads the plugin in the nix-daemon; the test
-      # drives `nix --store grpc://` directly, so load it globally too.
-      nix.settings.plugin-files = [ "${config.programs.nix-grpc-store.package}/lib/nix/plugins" ];
       services.nix-grpc-daemon = {
         enable = true;
         listen = "127.0.0.1:50051";
-        # Reuse the client build (against nix.package.libs) so the test
-        # doesn't compile the project twice.
+        # Reuse the client bundle so the test doesn't compile the project twice.
         package = config.programs.nix-grpc-store.package;
       };
       # Bulk-upload subtest needs the daemon to be a trusted user so

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -16,6 +16,7 @@ let
 in
 pkgs.testers.runNixOSTest {
   name = "nix-grpc-store";
+  globalTimeout = 600;
 
   nodes.machine =
     { config, lib, ... }:


### PR DESCRIPTION

The plugin is ABI-coupled to the Nix that dlopen()s it, so users running
a Nix other than the flake's pinned fork could not use it at all.

Build one plugin per Nix version that nixpkgs ships with split component
libraries (2.31, 2.34, 2.35, git), exposed as plugin-<version> packages
that double as compile checks. API differences between those versions
are handled in src/nix-compat.hh.
