### PR TITLE
daemon: add logfmt based client logging + per-client Prometheus counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,41 @@ presenting a certificate signed by that CA are accepted.
   * `--listen ADDR` — default `0.0.0.0:50051`
   * `--proxy-socket PATH` — nix-daemon socket, default `/nix/var/nix/daemon-socket/socket`
   * `--tls-cert`, `--tls-key`, `--client-ca` — see above
+  * `--metrics-listen ADDR` — serve Prometheus metrics; disabled if unset
+
+## Monitoring
+
+All gRPC clients act as the same local user, so activity is attributed to the
+client certificate CN (`cn=-` without mTLS). Have your CA put a user name in
+the CN and logs and metrics are per user.
+
+### Access log
+
+One logfmt line per RPC on stderr (journald):
+
+    ts=2025-01-15T12:03:41Z level=info event=session_end method=Connect cn=alice peer=ipv4:10.0.0.5:53211 duration_s=1832 bytes_in=52341 bytes_out=812345678
+
+  * `session_start` / `session_end` — tunnelled `Connect` sessions;
+    `session_end` adds `duration_s` and uncompressed `bytes_in` / `bytes_out`
+  * `rpc` — native RPCs (`QueryValidPaths`, `QueryPathInfos`,
+    `AddMultipleToStore`, `NarsFromPaths`) with `paths` and, for bulk
+    transfers, `duration_s` and `nar_bytes_in` / `nar_bytes_out`
+
+Every event carries `cn` and `peer`:
+`journalctl -u nix-grpc-daemon | grep cn=alice`.
+
+### Prometheus metrics
+
+With `--metrics-listen 127.0.0.1:9464` (NixOS:
+`services.nix-grpc-daemon.metricsListen`) the daemon serves `/metrics`:
+
+  * `nix_grpc_rpcs_total{method,cn}` — RPCs handled
+  * `nix_grpc_tunnel_bytes_total{direction,cn}` — uncompressed bytes through
+    the `Connect` tunnel
+  * `nix_grpc_nar_bytes_total{direction,cn}` — uncompressed NAR bytes
+    imported (`in`) / exported (`out`)
+
+Only CA-issued CNs appear as labels, so cardinality stays bounded.
 
 ## Tests
 

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,8 @@ protobuf_dep = dependency('protobuf')
 zstd_dep     = dependency('libzstd')
 threads_dep  = dependency('threads')
 
+prometheus_dep = [dependency('prometheus-cpp-core'), dependency('prometheus-cpp-pull')]
+
 nix_store_dep = dependency('nix-store')
 nix_util_dep  = dependency('nix-util')
 
@@ -99,6 +101,6 @@ executable('nix-grpc-daemon',
   include_directories : gen_inc,
   cpp_args : nix_compat_args,
   # nix-store: native QueryValidPaths / AddMultipleToStore handlers.
-  dependencies : common_deps + [nix_util_dep, nix_store_dep],
+  dependencies : common_deps + prometheus_dep + [nix_util_dep, nix_store_dep],
   install : true,
 )

--- a/nixos/server.nix
+++ b/nixos/server.nix
@@ -39,6 +39,13 @@ in
       description = "Address to listen on, in gRPC `host:port` form.";
     };
 
+    metricsListen = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "127.0.0.1:9464";
+      description = "Address to serve Prometheus metrics on. Disabled if unset.";
+    };
+
     proxySocket = lib.mkOption {
       type = lib.types.path;
       default = "/nix/var/nix/daemon-socket/socket";
@@ -128,6 +135,10 @@ in
           ++ lib.optionals (cfg.tls.clientCaFile != null) [
             "--client-ca"
             cfg.tls.clientCaFile
+          ]
+          ++ lib.optionals (cfg.metricsListen != null) [
+            "--metrics-listen"
+            cfg.metricsListen
           ]
           ++ cfg.extraFlags
         );

--- a/package.nix
+++ b/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   protobuf,
   grpc,
+  prometheus-cpp,
   zstd,
   # Nix component libraries. When building the client plugin these must be
   # ABI-compatible with the `nix` binary that will dlopen() the .so; the NixOS
@@ -30,6 +31,7 @@ stdenv.mkDerivation {
   buildInputs = [
     grpc
     protobuf
+    prometheus-cpp
     zstd
     nix-store
     nix-util

--- a/src/logfmt.hh
+++ b/src/logfmt.hh
@@ -1,0 +1,87 @@
+#pragma once
+// Minimal logfmt emitter for the daemon's access log. One key=value line per
+// event on stderr, so journald/Loki can parse it and journalctl stays readable.
+
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <initializer_list>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <grpc/grpc_security_constants.h>
+#include <grpcpp/grpcpp.h>
+
+namespace nixgrpc {
+
+// Quote a value if it contains characters that would break key=value parsing.
+inline auto logfmtValue(std::string_view value) -> std::string
+{
+    bool needsQuotes = value.empty();
+    for (char const chr : value) {
+        if (chr == ' ' || chr == '"' || chr == '=' || chr == '\\' || chr == '\n') {
+            needsQuotes = true;
+            break;
+        }
+    }
+    if (!needsQuotes) {
+        return std::string(value);
+    }
+    std::string out;
+    out.reserve(value.size() + 2);
+    out.push_back('"');
+    for (char const chr : value) {
+        if (chr == '"' || chr == '\\') {
+            out.push_back('\\');
+            out.push_back(chr);
+        } else if (chr == '\n') {
+            out += "\\n";
+        } else {
+            out.push_back(chr);
+        }
+    }
+    out.push_back('"');
+    return out;
+}
+
+// Emit one logfmt line: ts=… level=info key=value …
+inline void logLine(std::initializer_list<std::pair<std::string_view, std::string>> fields)
+{
+    auto const now = std::chrono::system_clock::now();
+    auto const secs = std::chrono::system_clock::to_time_t(now);
+    std::tm utc{};
+    gmtime_r(&secs, &utc);
+    std::array<char, sizeof("2000-01-01T00:00:00Z")> timestamp{};
+    static_cast<void>(std::strftime(timestamp.data(), timestamp.size(), "%Y-%m-%dT%H:%M:%SZ", &utc));
+
+    std::string line = "ts=";
+    line += timestamp.data();
+    line += " level=info";
+    for (const auto & [key, value] : fields) {
+        line += ' ';
+        line += key;
+        line += '=';
+        line += logfmtValue(value);
+    }
+    line += '\n';
+    // Single write keeps lines from interleaving across handler threads.
+    static_cast<void>(std::fputs(line.c_str(), stderr));
+}
+
+// TLS client identity (x509 CN) or "-" when the client did not present a
+// certificate (no --client-ca configured).
+inline auto clientCommonName(const grpc::ServerContext & context) -> std::string
+{
+    auto auth = context.auth_context();
+    if (auth) {
+        auto values = auth->FindPropertyValues(GRPC_X509_CN_PROPERTY_NAME);
+        if (!values.empty()) {
+            return {values.front().data(), values.front().size()};
+        }
+    }
+    return "-";
+}
+
+} // namespace nixgrpc

--- a/src/metrics.hh
+++ b/src/metrics.hh
@@ -1,0 +1,62 @@
+#pragma once
+// Per-client-CN Prometheus counters, served on --metrics-listen.
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <prometheus/counter.h>
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+
+namespace nixgrpc {
+
+class Metrics
+{
+    std::shared_ptr<prometheus::Registry> registry = std::make_shared<prometheus::Registry>();
+    std::unique_ptr<prometheus::Exposer> exposer;
+
+    prometheus::Family<prometheus::Counter> * rpcs =
+        &prometheus::BuildCounter()
+             .Name("nix_grpc_rpcs_total")
+             .Help("RPCs handled, by method and client certificate CN")
+             .Register(*registry);
+    prometheus::Family<prometheus::Counter> * tunnelBytes =
+        &prometheus::BuildCounter()
+             .Name("nix_grpc_tunnel_bytes_total")
+             .Help("Uncompressed bytes through the Connect tunnel, by direction and client certificate CN")
+             .Register(*registry);
+    prometheus::Family<prometheus::Counter> * narBytes =
+        &prometheus::BuildCounter()
+             .Name("nix_grpc_nar_bytes_total")
+             .Help("Uncompressed NAR bytes imported/exported, by direction and client certificate CN")
+             .Register(*registry);
+
+public:
+    // `listen` empty: keep counting but do not serve /metrics.
+    explicit Metrics(const std::string & listen)
+    {
+        if (!listen.empty()) {
+            exposer = std::make_unique<prometheus::Exposer>(listen);
+            exposer->RegisterCollectable(registry);
+        }
+    }
+
+    void countRpc(const std::string & method, const std::string & commonName)
+    {
+        rpcs->Add({{"method", method}, {"cn", commonName}}).Increment();
+    }
+
+    void countTunnelBytes(const std::string & commonName, uint64_t bytesIn, uint64_t bytesOut)
+    {
+        tunnelBytes->Add({{"direction", "in"}, {"cn", commonName}}).Increment(static_cast<double>(bytesIn));
+        tunnelBytes->Add({{"direction", "out"}, {"cn", commonName}}).Increment(static_cast<double>(bytesOut));
+    }
+
+    void countNarBytes(const std::string & direction, const std::string & commonName, uint64_t bytes)
+    {
+        narBytes->Add({{"direction", direction}, {"cn", commonName}}).Increment(static_cast<double>(bytes));
+    }
+};
+
+} // namespace nixgrpc

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -6,6 +6,8 @@
 // handled natively (via a Store opened on the same socket) so `nix copy`
 // avoids the tunnel's per-batch zstd flushes and per-path round trips.
 
+#include <atomic>
+#include <chrono>
 #include <csignal>
 #include <cstddef>
 #include <cstdint>
@@ -39,14 +41,13 @@
 #include <nix/util/error.hh>
 #include <nix/util/file-descriptor.hh>
 #include <nix/util/file-system.hh>
-#include <nix/util/fmt.hh>
-#include <nix/util/logging.hh>
 #include <nix/util/ref.hh>
 #include <nix/util/repair-flag.hh>
 #include <nix/util/serialise.hh>
 #include <nix/util/unix-domain-socket.hh>
 #include <nix/util/util.hh>
 
+#include "logfmt.hh"
 #include "nix-compat.hh"
 #include "nix_remote.grpc.pb.h"
 #include "nix_remote.pb.h"
@@ -87,14 +88,25 @@ class NixRemoteService final : public nix::remote::NixRemote::Service
         }
     }
 
+    static auto secondsSince(std::chrono::steady_clock::time_point start) -> std::string
+    {
+        auto const elapsed = std::chrono::steady_clock::now() - start;
+        return std::to_string(std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+    }
+
 public:
     explicit NixRemoteService(std::string socketPath)
         : socketPath(std::move(socketPath))
     {
     }
 
-    auto Connect(grpc::ServerContext * /*context*/, GrpcStream * stream) -> grpc::Status override
+    auto Connect(grpc::ServerContext * context, GrpcStream * stream) -> grpc::Status override
     {
+        auto const commonName = nixgrpc::clientCommonName(*context);
+        auto const peer = context->peer();
+        auto const start = std::chrono::steady_clock::now();
+        nixgrpc::logLine({{"event", "session_start"}, {"method", "Connect"}, {"cn", commonName}, {"peer", peer}});
+
         nix::AutoCloseFD sock;
         try {
             sock = nix::connect(std::filesystem::path{socketPath});
@@ -102,31 +114,47 @@ public:
             return {grpc::StatusCode::UNAVAILABLE, err.what()};
         }
 
+        std::atomic<uint64_t> bytesIn{0};
         std::thread receiver([&]() -> void {
             try {
-                nixgrpc::pumpStreamToFd(*stream, sock.get());
+                bytesIn = nixgrpc::pumpStreamToFd(*stream, sock.get());
             } catch (...) {
                 nix::ignoreExceptionInDestructor();
             }
             ::shutdown(sock.get(), SHUT_WR);
         });
 
+        uint64_t bytesOut = 0;
         try {
-            nixgrpc::pumpFdToStream(sock.get(), *stream);
+            bytesOut = nixgrpc::pumpFdToStream(sock.get(), *stream);
         } catch (...) {
             nix::ignoreExceptionInDestructor();
         }
 
         receiver.join();
+        nixgrpc::logLine(
+            {{"event", "session_end"},
+             {"method", "Connect"},
+             {"cn", commonName},
+             {"peer", peer},
+             {"duration_s", secondsSince(start)},
+             {"bytes_in", std::to_string(bytesIn.load())},
+             {"bytes_out", std::to_string(bytesOut)}});
         return grpc::Status::OK;
     }
 
     auto QueryValidPaths(
-        grpc::ServerContext * /*context*/,
+        grpc::ServerContext * context,
         const nix::remote::QueryValidPathsRequest * request,
         nix::remote::QueryValidPathsReply * reply) -> grpc::Status override
     {
         return guarded([&]() -> grpc::Status {
+            nixgrpc::logLine(
+                {{"event", "rpc"},
+                 {"method", "QueryValidPaths"},
+                 {"cn", nixgrpc::clientCommonName(*context)},
+                 {"peer", context->peer()},
+                 {"paths", std::to_string(request->paths_size())}});
             auto localStore = getStore();
             nix::StorePathSet paths;
             for (const auto & path : request->paths()) {
@@ -141,11 +169,14 @@ public:
     }
 
     auto AddMultipleToStore(
-        grpc::ServerContext * /*context*/,
+        grpc::ServerContext * context,
         AddMultipleReader * reader,
         nix::remote::AddMultipleReply * /*reply*/) -> grpc::Status override
     {
         return guarded([&]() -> grpc::Status {
+            auto const commonName = nixgrpc::clientCommonName(*context);
+            auto const peer = context->peer();
+            auto const start = std::chrono::steady_clock::now();
             auto localStore = getStore();
 
             nix::remote::AddMultipleChunk first;
@@ -162,6 +193,7 @@ public:
 
             // Same framing as nix::WorkerProto::Op::AddMultipleToStore.
             auto expected = nix::readNum<uint64_t>(source);
+            uint64_t narBytes = 0;
             for (uint64_t idx = 0; idx < expected; ++idx) {
                 auto info = nix::WorkerProto::Serialise<nix::ValidPathInfo>::read(
                     *localStore,
@@ -170,17 +202,32 @@ public:
                 nixcompat::EnsureRead wrapper{source, info.narSize};
                 localStore->addToStore(info, wrapper, repair, checkSigs);
                 wrapper.finish();
+                narBytes += info.narSize;
             }
+            nixgrpc::logLine(
+                {{"event", "rpc"},
+                 {"method", "AddMultipleToStore"},
+                 {"cn", commonName},
+                 {"peer", peer},
+                 {"duration_s", secondsSince(start)},
+                 {"paths", std::to_string(expected)},
+                 {"nar_bytes_in", std::to_string(narBytes)}});
             return grpc::Status::OK;
         });
     }
 
     auto QueryPathInfos(
-        grpc::ServerContext * /*context*/,
+        grpc::ServerContext * context,
         const nix::remote::QueryPathInfosRequest * request,
         nix::remote::QueryPathInfosReply * reply) -> grpc::Status override
     {
         return guarded([&]() -> grpc::Status {
+            nixgrpc::logLine(
+                {{"event", "rpc"},
+                 {"method", "QueryPathInfos"},
+                 {"cn", nixgrpc::clientCommonName(*context)},
+                 {"peer", context->peer()},
+                 {"paths", std::to_string(request->paths_size())}});
             auto localStore = getStore();
             for (const auto & path : request->paths()) {
                 std::shared_ptr<const nix::ValidPathInfo> info;
@@ -202,19 +249,37 @@ public:
         });
     }
 
-    auto NarsFromPaths(grpc::ServerContext * /*context*/, NarsStream * stream) -> grpc::Status override
+    auto NarsFromPaths(grpc::ServerContext * context, NarsStream * stream) -> grpc::Status override
     {
         return guarded([&]() -> grpc::Status {
+            auto const start = std::chrono::steady_clock::now();
             auto localStore = getStore();
             nixgrpc::ZstdWriterSink<NarsStream, nix::remote::NarChunk> sink(*stream);
+
+            uint64_t narBytes = 0;
+            nix::LambdaSink counting([&](std::string_view data) -> void {
+                sink(data);
+                narBytes += data.size();
+            });
+
+            uint64_t paths = 0;
             nix::remote::NarRequest request;
             while (stream->Read(&request)) {
-                localStore->narFromPath(nix::StorePath(request.path()), sink);
+                localStore->narFromPath(nix::StorePath(request.path()), counting);
                 // The client blocks on this NAR before sending the next
                 // request, so it must not linger in the encoder.
                 sink.flush();
+                ++paths;
             }
             sink.finish();
+            nixgrpc::logLine(
+                {{"event", "rpc"},
+                 {"method", "NarsFromPaths"},
+                 {"cn", nixgrpc::clientCommonName(*context)},
+                 {"peer", context->peer()},
+                 {"duration_s", secondsSince(start)},
+                 {"paths", std::to_string(paths)},
+                 {"nar_bytes_out", std::to_string(narBytes)}});
             return grpc::Status::OK;
         });
     }
@@ -307,7 +372,7 @@ try {
         throw nix::Error("failed to start gRPC server on '%s'", options.listen);
     }
 
-    nix::logger->log(nix::lvlInfo, nix::fmt("nix-grpc-daemon listening on %s → %s", options.listen, options.socketPath));
+    nixgrpc::logLine({{"event", "startup"}, {"listen", options.listen}, {"proxy_socket", options.socketPath}});
     server->Wait();
     return 0;
 } catch (const std::exception & err) {

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -48,6 +48,7 @@
 #include <nix/util/util.hh>
 
 #include "logfmt.hh"
+#include "metrics.hh"
 #include "nix-compat.hh"
 #include "nix_remote.grpc.pb.h"
 #include "nix_remote.pb.h"
@@ -62,6 +63,7 @@ namespace {
 class NixRemoteService final : public nix::remote::NixRemote::Service
 {
     std::string socketPath;
+    nixgrpc::Metrics & metrics;
 
     std::mutex storeMutex;
     std::shared_ptr<nix::Store> store;
@@ -95,8 +97,9 @@ class NixRemoteService final : public nix::remote::NixRemote::Service
     }
 
 public:
-    explicit NixRemoteService(std::string socketPath)
+    NixRemoteService(std::string socketPath, nixgrpc::Metrics & metrics)
         : socketPath(std::move(socketPath))
+        , metrics(metrics)
     {
     }
 
@@ -106,6 +109,7 @@ public:
         auto const peer = context->peer();
         auto const start = std::chrono::steady_clock::now();
         nixgrpc::logLine({{"event", "session_start"}, {"method", "Connect"}, {"cn", commonName}, {"peer", peer}});
+        metrics.countRpc("Connect", commonName);
 
         nix::AutoCloseFD sock;
         try {
@@ -140,6 +144,7 @@ public:
              {"duration_s", secondsSince(start)},
              {"bytes_in", std::to_string(bytesIn.load())},
              {"bytes_out", std::to_string(bytesOut)}});
+        metrics.countTunnelBytes(commonName, bytesIn, bytesOut);
         return grpc::Status::OK;
     }
 
@@ -149,12 +154,14 @@ public:
         nix::remote::QueryValidPathsReply * reply) -> grpc::Status override
     {
         return guarded([&]() -> grpc::Status {
+            auto const commonName = nixgrpc::clientCommonName(*context);
             nixgrpc::logLine(
                 {{"event", "rpc"},
                  {"method", "QueryValidPaths"},
-                 {"cn", nixgrpc::clientCommonName(*context)},
+                 {"cn", commonName},
                  {"peer", context->peer()},
                  {"paths", std::to_string(request->paths_size())}});
+            metrics.countRpc("QueryValidPaths", commonName);
             auto localStore = getStore();
             nix::StorePathSet paths;
             for (const auto & path : request->paths()) {
@@ -212,6 +219,8 @@ public:
                  {"duration_s", secondsSince(start)},
                  {"paths", std::to_string(expected)},
                  {"nar_bytes_in", std::to_string(narBytes)}});
+            metrics.countRpc("AddMultipleToStore", commonName);
+            metrics.countNarBytes("in", commonName, narBytes);
             return grpc::Status::OK;
         });
     }
@@ -222,12 +231,14 @@ public:
         nix::remote::QueryPathInfosReply * reply) -> grpc::Status override
     {
         return guarded([&]() -> grpc::Status {
+            auto const commonName = nixgrpc::clientCommonName(*context);
             nixgrpc::logLine(
                 {{"event", "rpc"},
                  {"method", "QueryPathInfos"},
-                 {"cn", nixgrpc::clientCommonName(*context)},
+                 {"cn", commonName},
                  {"peer", context->peer()},
                  {"paths", std::to_string(request->paths_size())}});
+            metrics.countRpc("QueryPathInfos", commonName);
             auto localStore = getStore();
             for (const auto & path : request->paths()) {
                 std::shared_ptr<const nix::ValidPathInfo> info;
@@ -252,6 +263,7 @@ public:
     auto NarsFromPaths(grpc::ServerContext * context, NarsStream * stream) -> grpc::Status override
     {
         return guarded([&]() -> grpc::Status {
+            auto const commonName = nixgrpc::clientCommonName(*context);
             auto const start = std::chrono::steady_clock::now();
             auto localStore = getStore();
             nixgrpc::ZstdWriterSink<NarsStream, nix::remote::NarChunk> sink(*stream);
@@ -275,11 +287,13 @@ public:
             nixgrpc::logLine(
                 {{"event", "rpc"},
                  {"method", "NarsFromPaths"},
-                 {"cn", nixgrpc::clientCommonName(*context)},
+                 {"cn", commonName},
                  {"peer", context->peer()},
                  {"duration_s", secondsSince(start)},
                  {"paths", std::to_string(paths)},
                  {"nar_bytes_out", std::to_string(narBytes)}});
+            metrics.countRpc("NarsFromPaths", commonName);
+            metrics.countNarBytes("out", commonName, narBytes);
             return grpc::Status::OK;
         });
     }
@@ -292,6 +306,7 @@ struct Options
     std::string tlsCert;
     std::string tlsKey;
     std::string clientCA;
+    std::string metricsListen;
 };
 
 auto parseOptions(const std::vector<std::string_view> & args) -> Options
@@ -315,6 +330,8 @@ auto parseOptions(const std::vector<std::string_view> & args) -> Options
             options.tlsKey = next();
         } else if (arg == "--client-ca") {
             options.clientCA = next();
+        } else if (arg == "--metrics-listen") {
+            options.metricsListen = next();
         } else {
             throw nix::Error("unknown flag '%s'", arg);
         }
@@ -358,7 +375,8 @@ try {
     const std::span args(argv, static_cast<size_t>(argc));
     auto options = parseOptions({args.begin(), args.end()});
 
-    NixRemoteService service(options.socketPath);
+    nixgrpc::Metrics metrics(options.metricsListen);
+    NixRemoteService service(options.socketPath, metrics);
 
     grpc::EnableDefaultHealthCheckService(true);
     grpc::ServerBuilder builder;

--- a/src/pump.hh
+++ b/src/pump.hh
@@ -14,6 +14,7 @@
 
 #include <cerrno>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <span>
 #include <string>
@@ -131,9 +132,11 @@ inline void zstdCompressInto(
 // Read from `sourceFd` until EOF, forwarding zstd-compressed batches to the
 // gRPC stream. Each batch is flushed as a self-contained decodable unit so
 // the peer never stalls waiting for more compressed bytes.
+// Returns the number of uncompressed bytes forwarded.
 template<class Stream>
-inline void pumpFdToStream(int sourceFd, Stream & stream)
+inline auto pumpFdToStream(int sourceFd, Stream & stream) -> uint64_t
 {
+    uint64_t total = 0;
     nix::remote::Chunk chunk;
     chunk.mutable_data()->reserve(ZSTD_compressBound(kChunkSize));
     std::string input(kChunkSize, '\0');
@@ -157,9 +160,10 @@ inline void pumpFdToStream(int sourceFd, Stream & stream)
         if (count <= 0) {
             break;
         }
+        total += static_cast<uint64_t>(count);
         encode({.src = input.data(), .size = static_cast<size_t>(count), .pos = 0}, ZSTD_e_flush);
         if (!stream.Write(chunk)) {
-            return;
+            return total;
         }
     }
 
@@ -167,13 +171,16 @@ inline void pumpFdToStream(int sourceFd, Stream & stream)
     if (!chunk.data().empty()) {
         stream.Write(chunk);
     }
+    return total;
 }
 
 // Read Chunks from the gRPC stream until it closes, forwarding
 // zstd-decompressed bytes into `sinkFd`.
+// Returns the number of decompressed bytes forwarded.
 template<class Stream>
-inline void pumpStreamToFd(Stream & stream, int sinkFd)
+inline auto pumpStreamToFd(Stream & stream, int sinkFd) -> uint64_t
 {
+    uint64_t total = 0;
     nix::remote::Chunk chunk;
     std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> const dctx{ZSTD_createDCtx(), ZSTD_freeDCtx};
     std::string out;
@@ -188,12 +195,14 @@ inline void pumpStreamToFd(Stream & stream, int sinkFd)
             zstdCheck(ZSTD_decompressStream(dctx.get(), &zout, &zin), "decompress");
             if (zout.pos != 0) {
                 nix::writeFull(sinkFd, {out.data(), zout.pos});
+                total += zout.pos;
             }
             if (zin.pos == zin.size && zout.pos < zout.size) {
                 break;
             }
         }
     }
+    return total;
 }
 
 // Sink that zstd-compresses written data into gRPC messages of type `Msg`

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -45,7 +45,10 @@ pkgs.testers.runNixOSTest {
       # nix copy --to can add unsigned paths.
       services.nix-grpc-daemon.trustClients = true;
 
-      environment.systemPackages = [ pkgs.perf ];
+      environment.systemPackages = [
+        pkgs.perf
+        pkgs.curl
+      ];
       # Allow perf to resolve kernel symbols and record system-wide as root.
       boot.kernel.sysctl."kernel.kptr_restrict" = 0;
       boot.kernel.sysctl."kernel.perf_event_paranoid" = -1;
@@ -98,7 +101,8 @@ pkgs.testers.runNixOSTest {
           ${lib.getExe config.services.nix-grpc-daemon.package} --listen 127.0.0.1:50052 \
             --proxy-socket /nix/var/nix/daemon-socket/socket \
             --tls-cert ${certDir}/server.pem --tls-key ${certDir}/server.key \
-            --client-ca ${certDir}/ca.pem
+            --client-ca ${certDir}/ca.pem \
+            --metrics-listen 127.0.0.1:9464
         '';
       };
     };
@@ -167,6 +171,12 @@ pkgs.testers.runNixOSTest {
         machine.succeed(
             "journalctl -u nix-grpc-daemon.service | "
             "grep -E 'event=session_end method=Connect cn=- '"
+        )
+
+    with subtest("prometheus metrics labelled by certificate CN"):
+        machine.succeed(
+            "curl -sf http://127.0.0.1:9464/metrics | "
+            "grep -E 'nix_grpc_rpcs_total\\{.*cn=\"localhost\".*method=\"Connect\".*\\} [0-9]+'"
         )
 
     with subtest("bulk upload over gRPC"):

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -159,6 +159,16 @@ pkgs.testers.runNixOSTest {
             "--no-link --print-out-paths"
         )
 
+    with subtest("access log attributes clients by certificate CN"):
+        machine.succeed(
+            "journalctl -u nix-grpc-daemon-mtls.service | "
+            "grep -E 'event=session_end method=Connect cn=localhost .*bytes_out=[0-9]+'"
+        )
+        machine.succeed(
+            "journalctl -u nix-grpc-daemon.service | "
+            "grep -E 'event=session_end method=Connect cn=- '"
+        )
+
     with subtest("bulk upload over gRPC"):
         # Exercises server-side writeFull() on the daemon socket under
         # backpressure (readCoalesced() shares the fd with this write path).


### PR DESCRIPTION

All gRPC clients act as the single nix-grpc-daemon user, so there is no
way to see which client is causing load. Log each RPC and Connect
session (with tunnelled byte counts) as logfmt lines including the mTLS
client certificate CN and peer address, so per-user activity can be
read from journalctl or Loki.

The logfmt access log shows what a client did, but finding out who
causes load over time means grepping journals. Serve RPC, tunnel-byte
and NAR-byte counters labelled by client certificate CN on an optional
--metrics-listen endpoint instead. Peer addresses are deliberately not
used as labels to keep cardinality bounded to CA-issued CNs.
