### PR TITLE
daemon: gate chatty access-log events behind --log-level debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ presenting a certificate signed by that CA are accepted.
   * `--proxy-socket PATH` — nix-daemon socket, default `/nix/var/nix/daemon-socket/socket`
   * `--tls-cert`, `--tls-key`, `--client-ca` — see above
   * `--metrics-listen ADDR` — serve Prometheus metrics; disabled if unset
+  * `--log-level info|debug` — access log verbosity, default `info`
 
 ## Monitoring
 
@@ -144,11 +145,13 @@ One logfmt line per RPC on stderr (journald):
 
     ts=2025-01-15T12:03:41Z level=info event=session_end method=Connect cn=alice peer=ipv4:10.0.0.5:53211 duration_s=1832 bytes_in=52341 bytes_out=812345678
 
-  * `session_start` / `session_end` — tunnelled `Connect` sessions;
-    `session_end` adds `duration_s` and uncompressed `bytes_in` / `bytes_out`
-  * `rpc` — native RPCs (`QueryValidPaths`, `QueryPathInfos`,
-    `AddMultipleToStore`, `NarsFromPaths`) with `paths` and, for bulk
-    transfers, `duration_s` and `nar_bytes_in` / `nar_bytes_out`
+  * `session_end` — tunnelled `Connect` session with `duration_s` and
+    uncompressed `bytes_in` / `bytes_out`
+  * `rpc` — bulk transfers (`AddMultipleToStore`, `NarsFromPaths`) with
+    `paths`, `duration_s` and `nar_bytes_in` / `nar_bytes_out`
+
+With `--log-level debug`, `session_start` and the path-query RPCs
+(`QueryValidPaths`, `QueryPathInfos`) are logged as well.
 
 Every event carries `cn` and `peer`:
 `journalctl -u nix-grpc-daemon | grep cn=alice`.

--- a/nixos/server.nix
+++ b/nixos/server.nix
@@ -39,11 +39,23 @@ in
       description = "Address to listen on, in gRPC `host:port` form.";
     };
 
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "info"
+        "debug"
+      ];
+      default = "info";
+      description = ''
+        Access log verbosity; `info` logs Connect sessions and bulk
+        transfers, `debug` also logs path queries and session starts.
+      '';
+    };
+
     metricsListen = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
       example = "127.0.0.1:9464";
-      description = "Address to serve Prometheus metrics on. Disabled if unset.";
+      description = "Address to serve Prometheus metrics on; disabled if unset.";
     };
 
     proxySocket = lib.mkOption {
@@ -139,6 +151,10 @@ in
           ++ lib.optionals (cfg.metricsListen != null) [
             "--metrics-listen"
             cfg.metricsListen
+          ]
+          ++ [
+            "--log-level"
+            cfg.logLevel
           ]
           ++ cfg.extraFlags
         );

--- a/src/logfmt.hh
+++ b/src/logfmt.hh
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <ctime>
 #include <initializer_list>
@@ -46,8 +47,10 @@ inline auto logfmtValue(std::string_view value) -> std::string
     return out;
 }
 
-// Emit one logfmt line: ts=… level=info key=value …
-inline void logLine(std::initializer_list<std::pair<std::string_view, std::string>> fields)
+enum class LogLevel : std::uint8_t { info, debug };
+
+// Emit one logfmt line: ts=… level=… key=value …
+inline void logLine(LogLevel level, std::initializer_list<std::pair<std::string_view, std::string>> fields)
 {
     auto const now = std::chrono::system_clock::now();
     auto const secs = std::chrono::system_clock::to_time_t(now);
@@ -58,7 +61,7 @@ inline void logLine(std::initializer_list<std::pair<std::string_view, std::strin
 
     std::string line = "ts=";
     line += timestamp.data();
-    line += " level=info";
+    line += level == LogLevel::debug ? " level=debug" : " level=info";
     for (const auto & [key, value] : fields) {
         line += ' ';
         line += key;

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <csignal>
 #include <cstddef>
+#include <initializer_list>
 #include <cstdint>
 #include <cstdio>
 #include <exception>
@@ -64,6 +65,7 @@ class NixRemoteService final : public nix::remote::NixRemote::Service
 {
     std::string socketPath;
     nixgrpc::Metrics & metrics;
+    nixgrpc::LogLevel logLevel;
 
     std::mutex storeMutex;
     std::shared_ptr<nix::Store> store;
@@ -90,6 +92,13 @@ class NixRemoteService final : public nix::remote::NixRemote::Service
         }
     }
 
+    void logDebug(std::initializer_list<std::pair<std::string_view, std::string>> fields)
+    {
+        if (logLevel == nixgrpc::LogLevel::debug) {
+            nixgrpc::logLine(nixgrpc::LogLevel::debug, fields);
+        }
+    }
+
     static auto secondsSince(std::chrono::steady_clock::time_point start) -> std::string
     {
         auto const elapsed = std::chrono::steady_clock::now() - start;
@@ -97,9 +106,10 @@ class NixRemoteService final : public nix::remote::NixRemote::Service
     }
 
 public:
-    NixRemoteService(std::string socketPath, nixgrpc::Metrics & metrics)
+    NixRemoteService(std::string socketPath, nixgrpc::Metrics & metrics, nixgrpc::LogLevel logLevel)
         : socketPath(std::move(socketPath))
         , metrics(metrics)
+        , logLevel(logLevel)
     {
     }
 
@@ -108,7 +118,7 @@ public:
         auto const commonName = nixgrpc::clientCommonName(*context);
         auto const peer = context->peer();
         auto const start = std::chrono::steady_clock::now();
-        nixgrpc::logLine({{"event", "session_start"}, {"method", "Connect"}, {"cn", commonName}, {"peer", peer}});
+        logDebug({{"event", "session_start"}, {"method", "Connect"}, {"cn", commonName}, {"peer", peer}});
         metrics.countRpc("Connect", commonName);
 
         nix::AutoCloseFD sock;
@@ -137,6 +147,7 @@ public:
 
         receiver.join();
         nixgrpc::logLine(
+            nixgrpc::LogLevel::info,
             {{"event", "session_end"},
              {"method", "Connect"},
              {"cn", commonName},
@@ -155,7 +166,7 @@ public:
     {
         return guarded([&]() -> grpc::Status {
             auto const commonName = nixgrpc::clientCommonName(*context);
-            nixgrpc::logLine(
+            logDebug(
                 {{"event", "rpc"},
                  {"method", "QueryValidPaths"},
                  {"cn", commonName},
@@ -212,6 +223,7 @@ public:
                 narBytes += info.narSize;
             }
             nixgrpc::logLine(
+                nixgrpc::LogLevel::info,
                 {{"event", "rpc"},
                  {"method", "AddMultipleToStore"},
                  {"cn", commonName},
@@ -232,7 +244,7 @@ public:
     {
         return guarded([&]() -> grpc::Status {
             auto const commonName = nixgrpc::clientCommonName(*context);
-            nixgrpc::logLine(
+            logDebug(
                 {{"event", "rpc"},
                  {"method", "QueryPathInfos"},
                  {"cn", commonName},
@@ -285,6 +297,7 @@ public:
             }
             sink.finish();
             nixgrpc::logLine(
+                nixgrpc::LogLevel::info,
                 {{"event", "rpc"},
                  {"method", "NarsFromPaths"},
                  {"cn", commonName},
@@ -307,6 +320,7 @@ struct Options
     std::string tlsKey;
     std::string clientCA;
     std::string metricsListen;
+    nixgrpc::LogLevel logLevel = nixgrpc::LogLevel::info;
 };
 
 auto parseOptions(const std::vector<std::string_view> & args) -> Options
@@ -332,6 +346,13 @@ auto parseOptions(const std::vector<std::string_view> & args) -> Options
             options.clientCA = next();
         } else if (arg == "--metrics-listen") {
             options.metricsListen = next();
+        } else if (arg == "--log-level") {
+            auto value = next();
+            if (value == "debug") {
+                options.logLevel = nixgrpc::LogLevel::debug;
+            } else if (value != "info") {
+                throw nix::Error("--log-level must be 'info' or 'debug'");
+            }
         } else {
             throw nix::Error("unknown flag '%s'", arg);
         }
@@ -376,7 +397,7 @@ try {
     auto options = parseOptions({args.begin(), args.end()});
 
     nixgrpc::Metrics metrics(options.metricsListen);
-    NixRemoteService service(options.socketPath, metrics);
+    NixRemoteService service(options.socketPath, metrics, options.logLevel);
 
     grpc::EnableDefaultHealthCheckService(true);
     grpc::ServerBuilder builder;
@@ -390,7 +411,9 @@ try {
         throw nix::Error("failed to start gRPC server on '%s'", options.listen);
     }
 
-    nixgrpc::logLine({{"event", "startup"}, {"listen", options.listen}, {"proxy_socket", options.socketPath}});
+    nixgrpc::logLine(
+        nixgrpc::LogLevel::info,
+        {{"event", "startup"}, {"listen", options.listen}, {"proxy_socket", options.socketPath}});
     server->Wait();
     return 0;
 } catch (const std::exception & err) {

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -38,6 +38,7 @@ pkgs.testers.runNixOSTest {
       services.nix-grpc-daemon = {
         enable = true;
         listen = "127.0.0.1:50051";
+        logLevel = "debug";
         # Reuse the client bundle so the test doesn't compile the project twice.
         package = config.programs.nix-grpc-store.package;
       };
@@ -171,6 +172,14 @@ pkgs.testers.runNixOSTest {
         machine.succeed(
             "journalctl -u nix-grpc-daemon.service | "
             "grep -E 'event=session_end method=Connect cn=- '"
+        )
+        # Path queries only show up at --log-level debug.
+        machine.succeed(
+            "journalctl -u nix-grpc-daemon.service | "
+            "grep -q 'level=debug event=rpc method=QueryValidPaths'"
+        )
+        machine.fail(
+            "journalctl -u nix-grpc-daemon-mtls.service | grep -q level=debug"
         )
 
     with subtest("prometheus metrics labelled by certificate CN"):


### PR DESCRIPTION

Path-query RPCs and session starts are the most frequent events but
carry no byte counts; a client probing thousands of already-present
paths would flood the journal. Log them only with --log-level debug
(services.nix-grpc-daemon.logLevel); byte and duration accounting stays
at info.
