### PR TITLE
plugin: also look for client certs in /var/lib/nix-grpc-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ client then has trusted-user privileges, so require client certs
     }];
 
 TLS uses the system CA bundle and the client key pair from
-`/run/nix-grpc-store` by default (see below).
+`/run/nix-grpc-store` or `/var/lib/nix-grpc-store` by default (see below).
 
 ## Quick start (manual)
 
@@ -122,8 +122,8 @@ presenting a certificate signed by that CA are accepted.
     `$SSL_CERT_FILE` or the system CA bundle
   * `client-cert`, `client-key` — PEM pair to present for mTLS; default to
     `$NIX_GRPC_CLIENT_CERT`/`$NIX_GRPC_CLIENT_KEY`, then `client.crt`/`client.key`
-    in `$XDG_DATA_HOME/nix-grpc-store`, then `/run/nix-grpc-store`
-    (unreadable candidates are skipped)
+    in `$XDG_DATA_HOME/nix-grpc-store`, then `/run/nix-grpc-store`, then
+    `/var/lib/nix-grpc-store` (unreadable candidates are skipped)
 
 ## Server flags
 

--- a/packages.nix
+++ b/packages.nix
@@ -14,7 +14,7 @@ lib.makeScope newScope (
     supportedNixVersions = builtins.filter (
       name:
       builtins.match "nix_[0-9]+_[0-9]+" name != null
-      && (builtins.tryEval (nixVersions.${name}.libs ? nix-store)).value or false
+      && (builtins.tryEval ((nixVersions.${name}.libs or { }) ? nix-store)).value or false
     ) (builtins.attrNames nixVersions);
   in
   {

--- a/src/grpc-store.cc
+++ b/src/grpc-store.cc
@@ -96,6 +96,7 @@ auto defaultClientCred(const char *envVar, const std::string &fileName) -> std::
     candidates.push_back(*home + "/.local/share/nix-grpc-store/" + fileName);
   }
   candidates.push_back("/run/nix-grpc-store/" + fileName);
+  candidates.push_back("/var/lib/nix-grpc-store/" + fileName);
   return firstReadable(candidates);
 }
 
@@ -126,8 +127,8 @@ private:
         "",
         "client-cert",
         "Path to a PEM client certificate chain to present for mTLS. Defaults to "
-        "`$NIX_GRPC_CLIENT_CERT`, then `client.crt` in `$XDG_DATA_HOME/nix-grpc-store` "
-        "or `/run/nix-grpc-store`."};
+        "`$NIX_GRPC_CLIENT_CERT`, then `client.crt` in `$XDG_DATA_HOME/nix-grpc-store`, "
+        "`/run/nix-grpc-store` or `/var/lib/nix-grpc-store`."};
 
     Setting<std::string> clientKey{
         this,

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -164,6 +164,19 @@ pkgs.testers.runNixOSTest {
             "--no-link --print-out-paths"
         )
 
+    with subtest("default client cert lookup in /var/lib/nix-grpc-store"):
+        machine.succeed(
+            "install -d /var/lib/nix-grpc-store",
+            "install -m 0644 ${certDir}/client.pem /var/lib/nix-grpc-store/client.crt",
+            "install -m 0600 ${certDir}/client.key /var/lib/nix-grpc-store/client.key",
+        )
+        # No client-cert/client-key URI params: falls back to /var/lib.
+        machine.succeed(
+            "nix store info --json --store "
+            "'grpc://localhost:50052?ca-cert=${certDir}/ca.pem'"
+        )
+        machine.succeed("rm -r /var/lib/nix-grpc-store")
+
     with subtest("access log attributes clients by certificate CN"):
         machine.succeed(
             "journalctl -u nix-grpc-daemon-mtls.service | "


### PR DESCRIPTION
Adds /var/lib/nix-grpc-store as the last fallback for client.crt/client.key (after $NIX_GRPC_CLIENT_CERT/KEY, $XDG_DATA_HOME/nix-grpc-store and /run/nix-grpc-store), giving NixOS clients a persistent root-managed location. Covered by a new VM subtest.

Also fixes packages.nix to not hard-fail when a nixpkgs' nixVersions entry lacks .libs (tryEval doesn't catch missing attributes), which broke evaluation when downstream flakes set nixpkgs.follows.