### PR TITLE
plugin: support darwin dispatcher bundles

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -42,6 +42,10 @@ lib.makeScope newScope (
         self.default
       ]
       ++ map (version: self.versionPlugins."plugin-${version}") supportedNixVersions;
+      postBuild = ''
+        rm -f "$out"/lib/nix/plugins/nix-grpc-store-loader.*
+        cp -L ${self.default}/lib/nix/plugins/nix-grpc-store-loader.* "$out"/lib/nix/plugins/
+      '';
       meta.mainProgram = "nix-grpc-daemon";
     };
   }

--- a/src/plugin-loader.cc
+++ b/src/plugin-loader.cc
@@ -35,8 +35,14 @@ void warn(const std::string &message) {
       message.c_str()));
 }
 
-// <this .so's directory>/../nix-grpc-store-versions/<major.minor>/nix-grpc-store.so
+// <this module's directory>/../nix-grpc-store-versions/<major.minor>/nix-grpc-store.<platform suffix>
 auto pluginForRunningNix() -> std::filesystem::path {
+#ifdef __APPLE__
+  constexpr auto pluginFile = "nix-grpc-store.dylib";
+#else
+  constexpr auto pluginFile = "nix-grpc-store.so";
+#endif
+
   Dl_info info{};
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): dladdr needs a data pointer
   if (dladdr(reinterpret_cast<void *>(&pluginForRunningNix), &info) == 0 ||
@@ -45,7 +51,7 @@ auto pluginForRunningNix() -> std::filesystem::path {
   }
   return std::filesystem::path(info.dli_fname).parent_path().parent_path() /
          "nix-grpc-store-versions" / majorMinor(nix::nixVersion) /
-         "nix-grpc-store.so";
+         pluginFile;
 }
 
 } // namespace


### PR DESCRIPTION
Fix darwin plugin dispatch, which previously failed because the loader searched for a linux `.so` and resolved its version directory relative to the single-version package instead of the dispatcher bundle. The loader now selects the platform-specific module suffix and is copied into the dispatcher so `dladdr()` anchors lookup beside all supported version plugins. Verified with a nix-darwin system build using Nix 2.35.1 and an actual x86_64-linux remote build from macOS over gRPC.