### PR TITLE
packages: only build plugins for Nix >= 2.31

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -11,10 +11,14 @@ lib.makeScope newScope (
   self:
   let
     # Nix releases from nixpkgs that ship split component libraries.
+    # 2.31 is the oldest release with ParsedURL::Authority and
+    # StoreConfig::getReference(), which the plugin relies on.
     supportedNixVersions = builtins.filter (
       name:
       builtins.match "nix_[0-9]+_[0-9]+" name != null
-      && (builtins.tryEval ((nixVersions.${name}.libs or { }) ? nix-store)).value or false
+      && (builtins.tryEval (
+        lib.versionAtLeast nixVersions.${name}.version "2.31" && (nixVersions.${name}.libs or { }) ? nix-store
+      )).value or false
     ) (builtins.attrNames nixVersions);
   in
   {


### PR DESCRIPTION

Nix 2.30 lacks ParsedURL::Authority and StoreConfig::getReference(),
so the plugin cannot compile against it. Skip nix_2_30 from stable
nixpkgs instead of failing the build.
