### PR TITLE
plugin-loader: block gRPC shutdown on Darwin

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -88,10 +88,17 @@ shared_module('nix-grpc-store',
 # Loaded via nix.conf `plugin-files`. It dlopen()s the build matching the
 # running Nix from the versions directory above, so merged installs of
 # several builds support all of their Nix versions.
+loader_deps = [dependency('dl')]
+loader_cpp_args = ['-DNIX_GRPC_MODULE_SUFFIX="' + module_suffix + '"']
+if host_machine.system() == 'darwin'
+  loader_deps += [grpc_dep]
+  loader_cpp_args += ['-DNIX_GRPC_BLOCKING_SHUTDOWN']
+endif
+
 shared_module('nix-grpc-store-loader',
   sources : ['src/plugin-loader.cc'],
-  cpp_args : ['-DNIX_GRPC_MODULE_SUFFIX="' + module_suffix + '"'],
-  dependencies : dependency('dl'),
+  cpp_args : loader_cpp_args,
+  dependencies : loader_deps,
   link_args : plugin_link_args,
   name_prefix : '',
   install : true,

--- a/src/plugin-loader.cc
+++ b/src/plugin-loader.cc
@@ -12,6 +12,10 @@
 #include <string>
 #include <string_view>
 
+#ifdef NIX_GRPC_BLOCKING_SHUTDOWN
+#include <grpc/grpc.h>
+#endif
+
 namespace nix {
 // Resolved from the host `nix` process at dlopen() time.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -19,6 +23,20 @@ extern std::string nixVersion;
 } // namespace nix
 
 namespace {
+
+#ifdef NIX_GRPC_BLOCKING_SHUTDOWN
+class GrpcRuntimeGuard
+{
+public:
+    GrpcRuntimeGuard() { grpc_init(); }
+    ~GrpcRuntimeGuard() { grpc_shutdown_blocking(); }
+
+    GrpcRuntimeGuard(const GrpcRuntimeGuard &) = delete;
+    GrpcRuntimeGuard(GrpcRuntimeGuard &&) = delete;
+    auto operator=(const GrpcRuntimeGuard &) -> GrpcRuntimeGuard & = delete;
+    auto operator=(GrpcRuntimeGuard &&) -> GrpcRuntimeGuard & = delete;
+};
+#endif
 
 // "2.31.5" / "2.35pre20260619_f8bb823a" -> "2.31" / "2.35"
 auto majorMinor(std::string_view version) -> std::string_view {
@@ -63,6 +81,12 @@ extern "C" void nix_plugin_entry() {
     warn("no plugin build for Nix " + nix::nixVersion);
     return;
   }
+
+#ifdef NIX_GRPC_BLOCKING_SHUTDOWN
+  // gRPC shutdown is asynchronous by default. Keep one process-wide reference
+  // so its final shutdown can block before OpenSSL's process-exit cleanup.
+  static const GrpcRuntimeGuard grpcRuntime;
+#endif
 
   // Leaked on purpose: the plugin stays registered for the process lifetime.
   void *handle = dlopen(plugin.c_str(), RTLD_NOW | RTLD_LOCAL);


### PR DESCRIPTION
gRPC performs its final shutdown asynchronously after short-lived Nix clients unload the remote store. On Darwin this can leave worker thread destructors using OpenSSL after its process-exit cleanup has freed global state, causing intermittent SIGSEGVs in `init_thread_destructor`.

Keep a loader-owned gRPC reference for the process lifetime and release it with `grpc_shutdown_blocking()`. This drains gRPC workers before OpenSSL cleanup starts. Meson limits the extra dependency and behavior to Darwin.

Observed crash stack:
```
OPENSSL_cleanup -> exit
init_thread_destructor -> CRYPTO_THREAD_unlock / OPENSSL_sk_num
EXC_BAD_ACCESS / SIGSEGV
```

Validation:
- Baseline Nix 2.31.5 TLS stress: 2 SIGSEGVs / 480 short-lived clients
- Fixed Nix 2.31.5 TLS stress: 0 / 2,400
- Fixed Nix 2.36pre TLS stress: 0 / 2,400
- Final Meson-gated build: 0 / 480
- `checks.aarch64-darwin.clang-tidy`
- aarch64-darwin dispatcher build
- x86_64-linux dispatcher build
- loader and plugin resolve same `libgrpc.55.dylib`