### PR TITLE
Readable errors for client certificate problems

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ grpc_dep     = dependency('grpc++')
 protobuf_dep = dependency('protobuf')
 zstd_dep     = dependency('libzstd')
 threads_dep  = dependency('threads')
+openssl_dep  = dependency('libcrypto')
 
 prometheus_dep = [dependency('prometheus-cpp-core'), dependency('prometheus-cpp-pull')]
 
@@ -77,7 +78,7 @@ shared_module('nix-grpc-store',
   # nix_plugin_entry() skips registering the store when the running Nix
   # version differs from the one the plugin was built against.
   cpp_args : nix_compat_args + ['-DNIX_GRPC_BUILT_AGAINST_NIX="' + nix_store_dep.version() + '"'],
-  dependencies : common_deps + nix_header_deps,
+  dependencies : common_deps + nix_header_deps + [openssl_dep],
   link_args : plugin_link_args,
   name_prefix : '',
   install : true,

--- a/package.nix
+++ b/package.nix
@@ -18,7 +18,17 @@
 stdenv.mkDerivation {
   pname = "nix-grpc-store";
   version = "0.1.0";
-  src = ./.;
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./.clang-tidy
+      ./meson.build
+      ./meson.options
+      ./proto
+      ./src
+      ./fuzz
+    ];
+  };
 
   nativeBuildInputs = [
     meson

--- a/package.nix
+++ b/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   protobuf,
   grpc,
+  openssl,
   prometheus-cpp,
   zstd,
   # Nix component libraries. When building the client plugin these must be
@@ -40,6 +41,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     grpc
+    openssl
     protobuf
     prometheus-cpp
     zstd

--- a/src/acl.hh
+++ b/src/acl.hh
@@ -59,6 +59,7 @@ class Acl
     std::vector<Rule> rules;
     // Separate from the glob rules so '*' cannot grant anonymous access.
     std::optional<Role> anonRole;
+    bool certRequired = false;
 
 public:
     [[nodiscard]] auto active() const -> bool
@@ -85,6 +86,11 @@ public:
         return anonRole;
     }
 
+    void requireCertificate()
+    {
+        certRequired = true;
+    }
+
     // nullopt means access denied.
     [[nodiscard]] auto roleFor(const std::optional<std::string> & commonName) const -> std::optional<Role>
     {
@@ -92,7 +98,7 @@ public:
             if (anonRole) {
                 return anonRole;
             }
-            return rules.empty() ? std::optional(Role::trusted) : std::nullopt;
+            return (certRequired || !rules.empty()) ? std::nullopt : std::optional(Role::trusted);
         }
         if (rules.empty()) {
             return Role::trusted;

--- a/src/grpc-store.cc
+++ b/src/grpc-store.cc
@@ -204,6 +204,7 @@ private:
     ref<const Config> config;
 
     std::shared_ptr<grpc::ChannelCredentials> creds;
+    bool haveClientCert = false;
 
     /* One channel is shared by all connections in the pool; gRPC multiplexes
        streams over it internally. The stub keeps the channel alive. */
@@ -243,13 +244,18 @@ public:
         }
         auto clientCert = config->clientCert.get();
         auto clientKey = config->clientKey.get();
-        if (clientCert.empty() && clientKey.empty()) {
+        if (clientCert.empty() != clientKey.empty()) {
+          throw Error("gRPC store '%s': client-cert and client-key must be set together",
+                      config->authority.to_string());
+        }
+        if (clientCert.empty()) {
           clientCert = defaultClientCred("NIX_GRPC_CLIENT_CERT", "client.crt");
           clientKey = defaultClientCred("NIX_GRPC_CLIENT_KEY", "client.key");
         }
         if (!clientCert.empty() && !clientKey.empty()) {
           ssl.pem_cert_chain = readFile(clientCert);
           ssl.pem_private_key = readFile(clientKey);
+          haveClientCert = true;
         }
         creds = grpc::SslCredentials(ssl);
       }
@@ -268,10 +274,30 @@ public:
     }
 
 private:
-    static void checkStatus(const grpc::Status & status, const char * opName)
+    auto statusError(const grpc::Status & status, const char * opName) const -> Error
+    {
+      std::string hint;
+      auto code = status.error_code();
+      // UNAVAILABLE: a TLS-level rejection shows up only as "Socket closed".
+      if (!config->insecure &&
+          (code == grpc::StatusCode::UNAUTHENTICATED || code == grpc::StatusCode::UNAVAILABLE)) {
+        hint = haveClientCert
+                   ? "\nhint: the server may have rejected the client certificate "
+                     "(untrusted CA or revoked)."
+                   : "\nhint: no client certificate was presented. If the server requires "
+                     "mTLS, set the 'client-cert'/'client-key' store parameters or install "
+                     "client.crt/client.key in $XDG_DATA_HOME/nix-grpc-store or "
+                     "/var/lib/nix-grpc-store.";
+      }
+      // NOLINTNEXTLINE(modernize-return-braced-init-list): Error ctor is explicit
+      return Error("gRPC %s on '%s' failed: %s%s", opName, config->authority.to_string(),
+                   status.error_message(), hint);
+    }
+
+    void checkStatus(const grpc::Status & status, const char * opName) const
     {
       if (!status.ok()) {
-        throw Error("gRPC %s failed: %s", opName, status.error_message());
+        throw statusError(status, opName);
       }
     }
 
@@ -734,6 +760,7 @@ private:
 
         std::thread reader;
         std::thread writer;
+        bool finished = false;
 
     public:
         Connection() = default;
@@ -762,7 +789,7 @@ private:
           if (writer.joinable()) {
             writer.join();
           }
-          if (stream) {
+          if (stream && !finished) {
             (void)stream->Finish();
           }
         }
@@ -874,11 +901,17 @@ auto GrpcStore::openConnection() -> ref<RemoteStore::Connection> {
     connPtr->toRemote.readSide.close();
   });
 
-  conn->writer = std::thread([connPtr = &*conn] -> void {
+  conn->writer = std::thread([this, connPtr = &*conn] -> void {
     try {
       nixgrpc::pumpStreamToFd(*connPtr->stream, connPtr->fromRemote.writeSide.get());
     } catch (...) {
       ignoreExceptionInDestructor();
+    }
+    // RemoteStore only sees EOF on the pipe, so surface the real status here.
+    auto status = connPtr->stream->Finish();
+    connPtr->finished = true;
+    if (!status.ok() && status.error_code() != grpc::StatusCode::CANCELLED) {
+      logError(statusError(status, "Connect").info());
     }
     // Propagate EOF / error to the worker-protocol reader.
     connPtr->fromRemote.writeSide.close();

--- a/src/grpc-store.cc
+++ b/src/grpc-store.cc
@@ -35,6 +35,10 @@
 #include <nix/util/serialise.hh>
 #include <nix/util/types.hh>
 #include <nix/util/util.hh>
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+#include <openssl/types.h>
+#include <openssl/x509.h>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -77,6 +81,26 @@ auto firstReadable(const std::vector<std::string> &candidates) -> std::string {
     }
   }
   return "";
+}
+
+// The server rejects an expired client cert during the TLS handshake, which
+// gRPC reports only as "Socket closed", so check up front.
+auto readValidCert(const std::string &path) -> std::string {
+  auto pem = nix::readFile(path);
+  std::unique_ptr<BIO, decltype(&BIO_free)> const bio{
+      BIO_new_mem_buf(pem.data(), static_cast<int>(pem.size())), BIO_free};
+  std::unique_ptr<X509, decltype(&X509_free)> const cert{
+      PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr), X509_free};
+  if (!cert) {
+    throw nix::Error("client certificate '%s' is not a valid PEM certificate", path);
+  }
+  if (X509_cmp_current_time(X509_get0_notAfter(cert.get())) < 0) {
+    throw nix::Error("client certificate '%s' has expired", path);
+  }
+  if (X509_cmp_current_time(X509_get0_notBefore(cert.get())) > 0) {
+    throw nix::Error("client certificate '%s' is not yet valid", path);
+  }
+  return pem;
 }
 
 // Same lookup order as Nix's ssl-cert-file setting.
@@ -253,7 +277,7 @@ public:
           clientKey = defaultClientCred("NIX_GRPC_CLIENT_KEY", "client.key");
         }
         if (!clientCert.empty() && !clientKey.empty()) {
-          ssl.pem_cert_chain = readFile(clientCert);
+          ssl.pem_cert_chain = readValidCert(clientCert);
           ssl.pem_private_key = readFile(clientKey);
           haveClientCert = true;
         }

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -148,11 +148,15 @@ class NixRemoteService final : public nix::remote::NixRemote::Service
              {"method", std::string(method)},
              {"cn", commonName},
              {"role", role ? std::string(nixgrpc::roleName(*role)) : "none"}});
-        auto const detail = role
-                                ? "role '" + std::string(nixgrpc::roleName(*role)) + "' may not call "
-                                      + std::string(method)
-                                : "no access rule matches certificate CN '" + commonName + "'";
-        return {grpc::StatusCode::PERMISSION_DENIED, detail};
+        if (role) {
+            return {
+                grpc::StatusCode::PERMISSION_DENIED,
+                "role '" + std::string(nixgrpc::roleName(*role)) + "' may not call " + std::string(method)};
+        }
+        if (!cert) {
+            return {grpc::StatusCode::UNAUTHENTICATED, "server requires a TLS client certificate"};
+        }
+        return {grpc::StatusCode::PERMISSION_DENIED, "no access rule matches certificate CN '" + commonName + "'"};
     }
 
 public:
@@ -798,6 +802,9 @@ auto parseOptions(const std::vector<std::string_view> & args) -> Options
         // Without mTLS every client's CN is "-".
         throw nix::Error("--allow/--allow-anonymous requires --client-ca");
     }
+    if (!options.clientCA.empty() && !options.acl.anonymousRole()) {
+        options.acl.requireCertificate();
+    }
     return options;
 }
 
@@ -809,15 +816,10 @@ auto makeServerCredentials(const Options & options) -> std::shared_ptr<grpc::Ser
         }
         return grpc::InsecureServerCredentials();
     }
-    // With --client-ca the server requires and verifies a client certificate
-    // (mTLS); --allow-anonymous downgrades "require" to "verify if
-    // presented" and the ACL sees cert-less clients as CN "-".
-    auto clientCertRequest = GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE;
-    if (!options.clientCA.empty()) {
-        clientCertRequest = options.acl.anonymousRole()
-                                ? GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY
-                                : GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY;
-    }
+    // Cert-less clients pass the handshake and are denied by the ACL with a
+    // readable UNAUTHENTICATED instead of an opaque "Socket closed".
+    auto const clientCertRequest = options.clientCA.empty() ? GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE
+                                                             : GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY;
     grpc::SslServerCredentialsOptions ssl(clientCertRequest);
     ssl.pem_key_cert_pairs.push_back(
         {.private_key = nix::readFile(options.tlsKey), .cert_chain = nix::readFile(options.tlsCert)});

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -142,6 +142,22 @@ pkgs.testers.runNixOSTest {
             --metrics-listen 127.0.0.1:9464
         '';
       };
+
+      systemd.services.nix-grpc-daemon-strict = {
+        wantedBy = [ "multi-user.target" ];
+        after = [
+          "nix-daemon.socket"
+          "nix-grpc-certs.service"
+        ];
+        requires = [ "nix-grpc-certs.service" ];
+        serviceConfig.ExecStart = ''
+          ${lib.getExe config.services.nix-grpc-daemon.package} --listen 127.0.0.1:50053 \
+            --proxy-socket /nix/var/nix/daemon-socket/socket \
+            --tls-cert ${certDir}/server.pem --tls-key ${certDir}/server.key \
+            --client-ca ${certDir}/ca.pem \
+            --allow localhost=trusted
+        '';
+      };
     };
 
   testScript = ''
@@ -204,6 +220,18 @@ pkgs.testers.runNixOSTest {
         machine.succeed(
             f"nix build --store '{store_mtls}' --impure -f /etc/hello.nix "
             "--no-link --print-out-paths"
+        )
+
+    with subtest("missing client cert yields a readable error"):
+        machine.wait_for_unit("nix-grpc-daemon-strict.service")
+        machine.wait_for_open_port(50053)
+        store_strict = "grpc://localhost:50053?ca-cert=${certDir}/ca.pem"
+        err = machine.fail(f"nix path-info --store '{store_strict}' '{p}' 2>&1")
+        print(err)
+        assert "requires a TLS client certificate" in err, err
+        machine.succeed(
+            f"nix path-info --store '{store_strict}&client-cert=${certDir}/client.pem"
+            f"&client-key=${certDir}/client.key' '{p}'"
         )
 
     with subtest("default client cert lookup in /var/lib/nix-grpc-store"):

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -229,6 +229,7 @@ pkgs.testers.runNixOSTest {
         err = machine.fail(f"nix path-info --store '{store_strict}' '{p}' 2>&1")
         print(err)
         assert "requires a TLS client certificate" in err, err
+        assert "no client certificate was presented" in err, err
         machine.succeed(
             f"nix path-info --store '{store_strict}&client-cert=${certDir}/client.pem"
             f"&client-key=${certDir}/client.key' '{p}'"

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -118,6 +118,10 @@ pkgs.testers.runNixOSTest {
           issue ro ro-client
           issue rw rw-client
           issue stranger stranger
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout expired.key -out expired.csr -subj /CN=localhost
+          openssl x509 -req -in expired.csr -not_before 20200101000000Z -not_after 20200102000000Z \
+            -CA ca.pem -CAkey ca.key -set_serial 0x$RANDOM -out expired.pem
           chmod a+r ${certDir}/*
         '';
       };
@@ -230,6 +234,11 @@ pkgs.testers.runNixOSTest {
         print(err)
         assert "requires a TLS client certificate" in err, err
         assert "no client certificate was presented" in err, err
+        err = machine.fail(
+            f"nix path-info --store '{store_strict}&client-cert=${certDir}/expired.pem"
+            f"&client-key=${certDir}/expired.key' '{p}' 2>&1"
+        )
+        assert "has expired" in err, err
         machine.succeed(
             f"nix path-info --store '{store_strict}&client-cert=${certDir}/client.pem"
             f"&client-key=${certDir}/client.key' '{p}'"


### PR DESCRIPTION
A client without (or with an expired) certificate talking to a `--client-ca` daemon only saw `UNAVAILABLE: Socket closed`.

- daemon: let cert-less clients finish the handshake and deny them per RPC with `UNAUTHENTICATED`
- plugin: name the host in status errors, hint at missing client certs, log the Connect stream status instead of a bare daemon EOF
- plugin: refuse expired / not-yet-valid client certificates before connecting