### PR TITLE
Build against nixpkgs' nixVersions.git instead of a Nix fork input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,91 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "git-hooks-nix": {
-      "inputs": {
-        "flake-compat": [
-          "nix"
-        ],
-        "nixpkgs": [
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
-        "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-23-11": "nixpkgs-23-11",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1785066688,
-        "narHash": "sha256-4QykV6vLkLg2SqnAgA9lvpCEFWNy76MlHFIuA3v0wHc=",
-        "owner": "Mic92",
-        "repo": "nix-1",
-        "rev": "cd1729d98a3f247e5f2d28028779ab6c400b2d97",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Mic92",
-        "repo": "nix-1",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1786106723,
@@ -102,41 +16,8 @@
         "type": "github"
       }
     },
-    "nixpkgs-23-11": {
-      "locked": {
-        "lastModified": 1717159533,
-        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "nix": "nix",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,22 +3,24 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nix.url = "github:Mic92/nix-1";
-    nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      nix,
     }:
     let
       lib = nixpkgs.lib;
+      # The default build and the VM tests track nixpkgs' git snapshot of Nix.
+      nixPackagesFor = pkgs: {
+        inherit (pkgs.nixVersions.git.libs) nix-store nix-util;
+        nix-everything = pkgs.nixVersions.git;
+      };
       packageSetFor =
         pkgs:
         pkgs.callPackage ./packages.nix {
-          nixPackages = nix.packages.${pkgs.stdenv.hostPlatform.system};
+          nixPackages = nixPackagesFor pkgs;
         };
       forAllSystems = lib.genAttrs [
         "x86_64-linux"
@@ -41,7 +43,7 @@
           bench-closure = nixpkgs.legacyPackages.${system}.callPackage ./tests/bench-closure.nix { };
           bench-latency = import ./tests/latency-test.nix {
             pkgs = nixpkgs.legacyPackages.${system};
-            nixPkgs = nix.packages.${system};
+            nixPkgs = nixPackagesFor nixpkgs.legacyPackages.${system};
             module = self.nixosModules.default;
           };
         }
@@ -68,7 +70,7 @@
         import ./checks.nix {
           pkgs = nixpkgs.legacyPackages.${system};
           packages = self.packages.${system};
-          nixPackages = nix.packages.${system};
+          nixPackages = nixPackagesFor nixpkgs.legacyPackages.${system};
           nixosModule = self.nixosModules.default;
         }
       );

--- a/packages.nix
+++ b/packages.nix
@@ -26,8 +26,7 @@ lib.makeScope newScope (
       inherit (nixPackages) nix-store nix-util;
     };
 
-    # One plugin per supported Nix version.
-    # "git" is only a compile check for the next release.
+    # One plugin per supported Nix release. nixVersions.git is `default`.
     versionPlugins = lib.listToAttrs (
       map (
         version:
@@ -36,7 +35,7 @@ lib.makeScope newScope (
             inherit (nixVersions.${version}.libs) nix-store nix-util;
           }
         )
-      ) (supportedNixVersions ++ [ "git" ])
+      ) supportedNixVersions
     );
 
     # The loader picks the one matching the running Nix, see meson.build.

--- a/src/grpc-store.cc
+++ b/src/grpc-store.cc
@@ -442,7 +442,7 @@ public:
           if (buildMode == bmNormal && store->alreadyValidResults(reqs)) {
             return;
           }
-          store->copyDrvsFromEvalStore(reqs, evalStore);
+          store->importDrvsFromEvalStore(reqs, evalStore);
           if (auto results = store->buildPathsWithResultsNative(reqs, buildMode)) {
             store->throwOnFailedBuilds(*results);
             return;
@@ -457,7 +457,7 @@ public:
               return std::move(*results);
             }
           }
-          store->copyDrvsFromEvalStore(reqs, evalStore);
+          store->importDrvsFromEvalStore(reqs, evalStore);
           if (auto results = store->buildPathsWithResultsNative(reqs, buildMode)) {
             return std::move(*results);
           }
@@ -484,7 +484,7 @@ public:
       if (buildMode == bmNormal && alreadyValidResults(reqs)) {
         return;
       }
-      copyDrvsFromEvalStore(reqs, evalStore);
+      importDrvsFromEvalStore(reqs, evalStore);
       if (auto results = buildPathsWithResultsNative(reqs, buildMode)) {
         throwOnFailedBuilds(*results);
         return;
@@ -500,7 +500,7 @@ public:
           return std::move(*results);
         }
       }
-      copyDrvsFromEvalStore(reqs, evalStore);
+      importDrvsFromEvalStore(reqs, evalStore);
       if (auto results = buildPathsWithResultsNative(reqs, buildMode)) {
         return std::move(*results);
       }
@@ -607,7 +607,7 @@ public:
 
     // The server cannot reach the client's eval store, so the .drvs are
     // imported first (content-addressed, passes signature checks).
-    void copyDrvsFromEvalStore(const std::vector<DerivedPath> & paths,
+    void importDrvsFromEvalStore(const std::vector<DerivedPath> & paths,
                                const std::shared_ptr<Store> & evalStore) {
       if (evalStore && evalStore.get() != this) {
         StorePathSet drvPaths;


### PR DESCRIPTION
The fork's boost patches no longer apply on current nixpkgs (CI build 55) and nothing here needs unreleased Nix changes anymore. The default plugin, dispatcher and VM tests now use nixpkgs' nixVersions.git. Renames copyDrvsFromEvalStore since RemoteStore has a private helper of that name which clang-tidy flags as shadowed.