### PR TITLE
Track NixOS/nix master via pinned nix-git.json

### DIFF
--- a/effects.nix
+++ b/effects.nix
@@ -1,0 +1,59 @@
+{ nixpkgs }:
+_args:
+let
+  pkgs = nixpkgs.legacyPackages.x86_64-linux;
+in
+{
+  # Weekly bump of nix-git.json so API breakage in Nix master shows up here
+  # before downstream flakes pull a newer nix. PRs carry the auto-merge label
+  # and land via .github/workflows/auto-merge.yaml once CI is green.
+  onSchedule.update-nix-git = {
+    when = {
+      dayOfWeek = [ "Mon" ];
+      hour = 4;
+      minute = 17;
+    };
+    # Plain derivation instead of nixbot's mkEffect to avoid the flake input.
+    # nixbot reads secretsMap and __nixbot_effect_checkout, see its
+    # docs/EFFECTS.md.
+    outputs.effects.update-nix-git =
+      pkgs.runCommand "effect-update-nix-git"
+        {
+          nativeBuildInputs = [
+            pkgs.cacert
+            pkgs.git
+            pkgs.gh
+            pkgs.nix
+            pkgs.jq
+          ];
+          secretsMap = builtins.toJSON { git.type = "GitToken"; };
+          __nixbot_effect_checkout = true;
+        }
+        ''
+          export HOME=/build/home
+          mkdir -p "$HOME"
+          export NIX_CONFIG="experimental-features = nix-command flakes"
+          GH_TOKEN=$(jq -r '.git.data.token' "$HERCULES_CI_SECRETS_JSON")
+          export GH_TOKEN
+          git config --global user.name "nix-grpc-store-bot"
+          git config --global user.email "nix-grpc-store-bot@users.noreply.github.com"
+          git config --global safe.directory '*'
+          cd "$NIXBOT_EFFECT_CHECKOUT"
+
+          bash scripts/update-nix-git.sh
+          if git diff --quiet nix-git.json; then
+            exit 0
+          fi
+          version=$(jq -r .version nix-git.json)
+          branch=update-nix-git
+          git checkout -b "$branch"
+          git commit -m "nix-git: bump to $version" nix-git.json
+          git push -f origin "$branch"
+          if ! gh pr view "$branch" --json state -q .state 2>/dev/null | grep -qx OPEN; then
+            gh pr create --head "$branch" --title "nix-git: bump to $version" \
+              --body "Automated bump of nix-git.json to current NixOS/nix master." \
+              --label auto-merge
+          fi
+        '';
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,33 @@
     }:
     let
       lib = nixpkgs.lib;
-      # The default build and the VM tests track nixpkgs' git snapshot of Nix.
-      nixPackagesFor = pkgs: {
-        inherit (pkgs.nixVersions.git.libs) nix-store nix-util;
-        nix-everything = pkgs.nixVersions.git;
-      };
+      # The default build and the VM tests track NixOS/nix master. nixpkgs'
+      # nixVersions.git lags behind, so pin master in nix-git.json (bumped
+      # weekly by the update-nix-git effect) to see API breakage here first.
+      nixGitPin = lib.importJSON ./nix-git.json;
+      nixGitFor =
+        pkgs:
+        ((pkgs.nixVersions.nixComponents_git.overrideSource (
+          pkgs.fetchFromGitHub {
+            inherit (nixGitPin)
+              owner
+              repo
+              rev
+              hash
+              ;
+          }
+        )).overrideScope
+          (_final: _prev: { inherit (nixGitPin) version; })
+        ).nix-everything;
+      nixPackagesFor =
+        pkgs:
+        let
+          nix-everything = nixGitFor pkgs;
+        in
+        {
+          inherit (nix-everything.libs) nix-store nix-util;
+          inherit nix-everything;
+        };
       packageSetFor =
         pkgs:
         pkgs.callPackage ./packages.nix {
@@ -64,6 +86,8 @@
           self.nixosModules.client
         ];
       };
+
+      herculesCI = import ./effects.nix { inherit nixpkgs; };
 
       checks = forAllSystems (
         system:

--- a/nix-git.json
+++ b/nix-git.json
@@ -1,0 +1,7 @@
+{
+  "owner": "NixOS",
+  "repo": "nix",
+  "rev": "df1878b6dd37ecc9360a5860ab5f90cee20ee5eb",
+  "hash": "sha256-aHQeWwfstVVdxOcmqJkv9QXqODmiyttH97M4ERaofw0=",
+  "version": "2.36.0pre20260828_df1878b6"
+}

--- a/scripts/update-nix-git.sh
+++ b/scripts/update-nix-git.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Bump nix-git.json to the latest NixOS/nix master commit.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+pin=nix-git.json
+
+owner=$(jq -r .owner "$pin")
+repo=$(jq -r .repo "$pin")
+old_rev=$(jq -r .rev "$pin")
+
+new_rev=$(git ls-remote "https://github.com/$owner/$repo" refs/heads/master | cut -f1)
+if [[ "$new_rev" == "$old_rev" ]]; then
+  echo "nix-git already at $new_rev"
+  exit 0
+fi
+
+prefetch=$(nix flake prefetch --json "github:$owner/$repo/$new_rev")
+hash=$(jq -r .hash <<<"$prefetch")
+store_path=$(jq -r .storePath <<<"$prefetch")
+last_modified=$(jq -r .locked.lastModified <<<"$prefetch")
+
+base_version=$(tr -d '\n' <"$store_path/.version")
+date=$(date -u -d "@$last_modified" +%Y%m%d)
+version="${base_version}pre${date}_${new_rev:0:8}"
+
+jq -n \
+  --arg owner "$owner" --arg repo "$repo" --arg rev "$new_rev" \
+  --arg hash "$hash" --arg version "$version" \
+  '{owner: $owner, repo: $repo, rev: $rev, hash: $hash, version: $version}' \
+  >"$pin.tmp"
+mv "$pin.tmp" "$pin"
+
+echo "nix-git: $old_rev -> $new_rev ($version)"


### PR DESCRIPTION
nixpkgs' nixVersions.git lags weeks behind master, so downstream flakes following nix master hit Store API breakage before this repo's CI does. Pin master in nix-git.json and bump it weekly through a nixbot scheduled effect that opens an auto-merge PR.

The pin starts one commit behind master so the first scheduled run exercises the updater.