### PR TITLE
plugin: move the gRPC shutdown guard from the loader into the plugin

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -23,6 +23,11 @@ lib.filterAttrs (name: _: lib.hasPrefix "plugin-" name) packages
     doCheck = false;
     dontFixup = true;
   });
+  exit-stress = import ./tests/exit-stress.nix {
+    inherit pkgs;
+    nix = nixPackages.nix-everything;
+    package = packages.default;
+  };
 }
 // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   sanitize-smoke = import ./tests/sanitize-smoke.nix {

--- a/meson.build
+++ b/meson.build
@@ -90,17 +90,11 @@ shared_module('nix-grpc-store',
 # Loaded via nix.conf `plugin-files`. It dlopen()s the build matching the
 # running Nix from the versions directory above, so merged installs of
 # several builds support all of their Nix versions.
-loader_deps = [dependency('dl')]
-loader_cpp_args = ['-DNIX_GRPC_MODULE_SUFFIX="' + module_suffix + '"']
-if host_machine.system() == 'darwin'
-  loader_deps += [grpc_dep]
-  loader_cpp_args += ['-DNIX_GRPC_BLOCKING_SHUTDOWN']
-endif
 
 shared_module('nix-grpc-store-loader',
   sources : ['src/plugin-loader.cc'],
-  cpp_args : loader_cpp_args,
-  dependencies : loader_deps,
+  cpp_args : ['-DNIX_GRPC_MODULE_SUFFIX="' + module_suffix + '"'],
+  dependencies : dependency('dl'),
   link_args : plugin_link_args,
   name_prefix : '',
   install : true,

--- a/src/grpc-store.cc
+++ b/src/grpc-store.cc
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <grpc/grpc.h>
 #include <grpc/impl/channel_arg_names.h>
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/support/channel_arguments.h>
@@ -36,6 +37,7 @@
 #include <nix/util/types.hh>
 #include <nix/util/util.hh>
 #include <openssl/bio.h>
+#include <openssl/crypto.h>
 #include <openssl/pem.h>
 #include <openssl/types.h>
 #include <openssl/x509.h>
@@ -130,6 +132,28 @@ auto defaultClientCred(const char *envVar, const std::string &fileName) -> std::
   candidates.push_back("/run/nix-grpc-store/" + fileName);
   candidates.push_back("/var/lib/nix-grpc-store/" + fileName);
   return firstReadable(candidates);
+}
+
+// grpc_shutdown() is asynchronous, so gRPC worker threads can still touch
+// OpenSSL while its atexit cleanup frees global state (SIGSEGV on Darwin
+// with short-lived clients). Hold one reference for the process lifetime and
+// release it with the blocking variant. Initialising OpenSSL first orders its
+// atexit handler before ours. Taken on first store use rather than at plugin
+// load: nix-daemon loads plugins too and its forked workers must not run
+// gRPC shutdown at exit.
+void retainGrpcRuntime() {
+  struct GrpcRuntime {
+    GrpcRuntime() {
+      OPENSSL_init_crypto(0, nullptr);
+      grpc_init();
+    }
+    ~GrpcRuntime() { grpc_shutdown_blocking(); }
+    GrpcRuntime(const GrpcRuntime &) = delete;
+    GrpcRuntime(GrpcRuntime &&) = delete;
+    auto operator=(const GrpcRuntime &) -> GrpcRuntime & = delete;
+    auto operator=(GrpcRuntime &&) -> GrpcRuntime & = delete;
+  };
+  static const GrpcRuntime grpcRuntime;
 }
 
 } // namespace
@@ -947,6 +971,7 @@ auto GrpcStore::openConnection() -> ref<RemoteStore::Connection> {
 }
 
 auto GrpcStoreConfig::openStore() const -> ref<Store> {
+  retainGrpcRuntime();
   return make_ref<GrpcStore>(ref{shared_from_this()});
 }
 

--- a/src/plugin-loader.cc
+++ b/src/plugin-loader.cc
@@ -14,10 +14,6 @@
 #include <string>
 #include <system_error>
 
-#ifdef NIX_GRPC_BLOCKING_SHUTDOWN
-#include <grpc/grpc.h>
-#endif
-
 namespace {
 
 auto nixStoreSoname(const std::string &soversion) -> std::string {
@@ -36,20 +32,6 @@ auto hostHas(const std::string &soname) -> bool {
   dlclose(handle);
   return true;
 }
-
-#ifdef NIX_GRPC_BLOCKING_SHUTDOWN
-class GrpcRuntimeGuard
-{
-public:
-    GrpcRuntimeGuard() { grpc_init(); }
-    ~GrpcRuntimeGuard() { grpc_shutdown_blocking(); }
-
-    GrpcRuntimeGuard(const GrpcRuntimeGuard &) = delete;
-    GrpcRuntimeGuard(GrpcRuntimeGuard &&) = delete;
-    auto operator=(const GrpcRuntimeGuard &) -> GrpcRuntimeGuard & = delete;
-    auto operator=(GrpcRuntimeGuard &&) -> GrpcRuntimeGuard & = delete;
-};
-#endif
 
 // nix::warn() would drag in more of the Nix ABI, so use plain stderr.
 void warn(const std::string &message) {
@@ -97,12 +79,6 @@ extern "C" void nix_plugin_entry() {
          versionsDir().string() + "'");
     return;
   }
-
-#ifdef NIX_GRPC_BLOCKING_SHUTDOWN
-  // gRPC shutdown is asynchronous by default. Keep one process-wide reference
-  // so its final shutdown can block before OpenSSL's process-exit cleanup.
-  static const GrpcRuntimeGuard grpcRuntime;
-#endif
 
   // Leaked on purpose: the plugin stays registered for the process lifetime.
   void *handle = dlopen(plugin.c_str(), RTLD_NOW | RTLD_LOCAL);

--- a/tests/exit-stress.nix
+++ b/tests/exit-stress.nix
@@ -1,0 +1,67 @@
+# Many short-lived TLS clients: catches races between gRPC's asynchronous
+# shutdown and OpenSSL's atexit cleanup (seen as SIGSEGV on Darwin).
+{
+  pkgs,
+  package,
+  nix,
+  iterations ? 400,
+}:
+pkgs.stdenv.mkDerivation {
+  name = "nix-grpc-store-exit-stress";
+  nativeBuildInputs = [
+    nix
+    package
+    pkgs.openssl
+  ];
+  __darwinAllowLocalNetworking = true;
+  buildCommand = ''
+    export HOME=$TMPDIR
+    export NIX_DAEMON_SOCKET_PATH=$TMPDIR/daemon.sock
+    export NIX_CONFIG="experimental-features = nix-command"
+
+    openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj /CN=stress-ca \
+      -keyout ca.key -out ca.pem 2>/dev/null
+    openssl req -newkey rsa:2048 -nodes -subj /CN=localhost \
+      -keyout server.key -out server.csr 2>/dev/null
+    openssl x509 -req -in server.csr -days 1 -CA ca.pem -CAkey ca.key \
+      -extfile <(printf 'subjectAltName=IP:127.0.0.1') -out server.pem 2>/dev/null
+
+    # Parallel builds on one Darwin host share the network namespace.
+    port=$((20000 + RANDOM % 20000))
+    trap 'rc=$?; kill %1 %2 2>/dev/null || true; [ $rc = 0 ] || cat nixd.log daemon.log' EXIT
+    nix daemon --store "local?root=$TMPDIR/remote" 2> nixd.log &
+    for _ in $(seq 50); do
+      [ -e "$NIX_DAEMON_SOCKET_PATH" ] && break
+      sleep 0.2
+    done
+    nix-grpc-daemon --listen 127.0.0.1:$port \
+      --proxy-socket "$NIX_DAEMON_SOCKET_PATH" \
+      --proxy-store "unix://$NIX_DAEMON_SOCKET_PATH?root=$TMPDIR/remote" \
+      --tls-cert server.pem --tls-key server.key 2> daemon.log &
+
+    plugin=$(echo ${package}/lib/nix/nix-grpc-store-versions/*/nix-grpc-store.*)
+    store="grpc://127.0.0.1:$port?ca-cert=$PWD/ca.pem"
+    client() { nix --option plugin-files "$plugin" store info --store "$store" "$@"; }
+
+    for _ in $(seq 50); do
+      client > /dev/null 2>&1 && break
+      sleep 0.2
+    done
+    client
+
+    crashes=0
+    for i in $(seq ${toString iterations}); do
+      client > /dev/null 2> client.log || {
+        rc=$?
+        if [ "$rc" -gt 128 ]; then
+          echo "iteration $i: killed by signal $((rc - 128))"
+          cat client.log
+          crashes=$((crashes + 1))
+        fi
+      }
+    done
+    echo "crashes: $crashes / ${toString iterations}"
+    [ "$crashes" = 0 ]
+    touch $out
+  '';
+}


### PR DESCRIPTION
Follow-up to #24.

- guard lives in the plugin, loader stays dependency-free
- enabled on all platforms
- OpenSSL is initialised before grpc_init() so the atexit order is deterministic
- only taken when a grpc:// store is opened: nix-daemon loads plugins too and its forked workers hung in grpc_shutdown_blocking()

New `exit-stress` check (400 short-lived TLS clients), aarch64-darwin: 8/400 crashes without a guard, 0/400 with.