### PR TITLE
fuzz every peer-controlled parser

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -43,25 +43,14 @@ lib.filterAttrs (name: _: lib.hasPrefix "plugin-" name) packages
     });
   };
 
-  # Quick libFuzzer run over the zstd chunk decoder (peer-controlled input).
-  fuzz = (packages.default.override { stdenv = pkgs.clangStdenv; }).overrideAttrs (old: {
-    pname = "nix-grpc-store-fuzz";
-    mesonFlags = (old.mesonFlags or [ ]) ++ [
-      "-Dfuzzers=true"
-      "-Db_sanitize=address,undefined"
-      "-Db_lundef=false"
-    ];
-    hardeningDisable = [ "fortify" ];
-    nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.zstd ];
-    installPhase = ''
-      mkdir corpus
-      printf 'seed' | zstd -o corpus/valid.zst
-      ASAN_OPTIONS=detect_leaks=0 ./fuzz-zstd-reader -max_total_time=30 corpus
-      touch $out
-    '';
-    doCheck = false;
-    dontFixup = true;
-  });
+  # Smoke run so the fuzz targets keep compiling and do not crash on an
+  # empty input; real campaigns run locally via scripts/fuzz.sh.
+  fuzz = pkgs.runCommand "nix-grpc-store-fuzz-smoke" { } ''
+    for f in ${packages.fuzzers}/bin/fuzz-*; do
+      "$f" -runs=200 2>&1 | tail -n2
+    done
+    touch $out
+  '';
 
   # Exercises the README ACME/step-ca substituter example.
   acme-vm = import ./tests/acme-substituter-test.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,12 @@
           scope = packageSetFor nixpkgs.legacyPackages.${system};
         in
         {
-          inherit (scope) default plugin-dispatcher fuzzers;
+          inherit (scope)
+            default
+            plugin-dispatcher
+            fuzzers
+            fuzzers-coverage
+            ;
         }
         // scope.versionPlugins
         // lib.optionalAttrs (lib.hasSuffix "-linux" system) {

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,13 @@
               ;
           }
         )).overrideScope
-          (_final: _prev: { inherit (nixGitPin) version; })
+          (
+            _final: prev: {
+              inherit (nixGitPin) version;
+              # Pending upstream; drop once merged.
+              patches = prev.patches ++ [ ./patches/nix-readstring-no-prealloc.patch ];
+            }
+          )
         ).nix-everything;
       nixPackagesFor =
         pkgs:
@@ -57,7 +63,7 @@
           scope = packageSetFor nixpkgs.legacyPackages.${system};
         in
         {
-          inherit (scope) default plugin-dispatcher;
+          inherit (scope) default plugin-dispatcher fuzzers;
         }
         // scope.versionPlugins
         // lib.optionalAttrs (lib.hasSuffix "-linux" system) {

--- a/fuzz/acl.cc
+++ b/fuzz/acl.cc
@@ -1,0 +1,51 @@
+// ACL rule parsing + CN matching, and the logfmt escaper the CN is logged
+// through: a CN must never be able to break out of its log line.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <nix/util/error.hh>
+
+#include "../src/acl.hh"
+#include "../src/logfmt.hh"
+#include "support.hh"
+
+extern "C" auto LLVMFuzzerTestOneInput(const uint8_t * raw, size_t size) -> int
+{
+    auto input = nixgrpc::fuzz::view(raw, size);
+
+    // Layout: rule\nrule\n...\0cn
+    auto sep = input.find('\0');
+    auto rules = input.substr(0, sep);
+    std::optional<std::string> commonName;
+    if (sep != std::string_view::npos) {
+        commonName = std::string(input.substr(sep + 1));
+    }
+
+    nixgrpc::Acl acl;
+    while (!rules.empty()) {
+        auto eol = rules.find('\n');
+        try {
+            acl.addRule(rules.substr(0, eol));
+        } catch (nix::Error &) {
+        }
+        if (eol == std::string_view::npos) {
+            break;
+        }
+        rules.remove_prefix(eol + 1);
+    }
+    auto role = acl.roleFor(commonName);
+    if (acl.active() && commonName && commonName->contains('\0') && role) {
+        std::abort();
+    }
+
+    auto escaped = nixgrpc::logfmtValue(commonName.value_or(""));
+    if (escaped.contains('\n') || escaped.empty()) {
+        std::abort();
+    }
+    return 0;
+}

--- a/fuzz/build-log.cc
+++ b/fuzz/build-log.cc
@@ -1,0 +1,22 @@
+// Worker-protocol stderr stream from the backend daemon.
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <string>
+
+#include <nix/util/error.hh>
+#include <nix/util/serialise.hh>
+
+#include "../src/build-log.hh"
+#include "support.hh"
+
+extern "C" auto LLVMFuzzerTestOneInput(const uint8_t * raw, size_t size) -> int
+{
+    nix::StringSource source(nixgrpc::fuzz::view(raw, size));
+    try {
+        nixgrpc::relayBuildLog(source, [](std::string line) -> void { static_cast<void>(line); });
+    } catch (std::exception &) { // NOLINT(bugprone-empty-catch): mirrors NixRemoteService::guarded()
+    }
+    return 0;
+}

--- a/fuzz/import-paths.cc
+++ b/fuzz/import-paths.cc
@@ -1,0 +1,56 @@
+// AddMultipleToStore body as the daemon sees it: the fuzz input is the
+// *plaintext* framing (count, ValidPathInfos, NARs), which we compress with
+// ZstdWriterSink at input-chosen flush points and feed back through
+// ZstdReaderSource in input-chosen message sizes. That way libFuzzer mutates
+// the parser input directly while the real decode path (short reads across
+// message boundaries) is still exercised.
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <string_view>
+
+#include <nix/util/archive.hh>
+#include <nix/util/error.hh>
+#include <nix/util/fs-sink.hh>
+#include <nix/util/serialise.hh>
+
+#include "nix_remote.pb.h"
+#include "../src/import-paths.hh"
+#include "../src/pump.hh"
+#include "support.hh"
+
+extern "C" auto LLVMFuzzerTestOneInput(const uint8_t * raw, size_t size) -> int
+{
+    using namespace nixgrpc::fuzz;
+    using Msg = nix::remote::AddMultipleChunk;
+    auto & dummy = store();
+
+    size_t const msgSize = (takeByte(raw, size) + 1U) * 16U;
+    size_t const flushEvery = (takeByte(raw, size) + 1U) * 8U;
+    auto plain = view(raw, size);
+
+    CollectWriter<Msg> collected;
+    {
+        nixgrpc::ZstdWriterSink<CollectWriter<Msg>, Msg> sink(collected);
+        while (!plain.empty()) {
+            auto piece = plain.substr(0, flushEvery);
+            sink(piece);
+            sink.flush();
+            plain.remove_prefix(piece.size());
+        }
+        sink.finish();
+    }
+
+    ChunkReader<Msg> reader{.data = collected.out, .chunk = msgSize};
+    nixgrpc::ZstdReaderSource<ChunkReader<Msg>, Msg> source(reader, {});
+    try {
+        nixgrpc::importPaths(dummy, source, [](const nix::ValidPathInfo &, nix::Source & nar) -> void {
+            // The daemon hands this to addToStore(), which parses a NAR.
+            nix::NullFileSystemObjectSink null;
+            nix::parseDump(null, nar);
+        });
+    } catch (std::exception &) { // NOLINT(bugprone-empty-catch): mirrors NixRemoteService::guarded()
+    }
+    return 0;
+}

--- a/fuzz/nar-frames.cc
+++ b/fuzz/nar-frames.cc
@@ -1,0 +1,80 @@
+// Client side of FetchNars: server-controlled NarFrame path_index/eof/data
+// demultiplexed into per-path spools. Input is a list of frames
+// [index][flags][len][payload]; flag bit 1 sends payload through a shared
+// zstd stream (as a real server would), otherwise raw bytes hit the decoder.
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <zstd.h>
+
+#include <nix/util/error.hh>
+
+#include "nix_remote.pb.h"
+#include "../src/nar-fetcher.hh"
+#include "../src/pump.hh"
+#include "support.hh"
+
+namespace {
+
+struct FrameReader
+{
+    std::vector<nix::remote::NarFrame> frames;
+    size_t next = 0;
+
+    auto Read(nix::remote::NarFrame * msg) -> bool
+    {
+        if (next == frames.size()) {
+            return false;
+        }
+        *msg = std::move(frames[next++]);
+        return true;
+    }
+};
+
+} // namespace
+
+extern "C" auto LLVMFuzzerTestOneInput(const uint8_t * raw, size_t size) -> int
+{
+    using namespace nixgrpc::fuzz;
+    constexpr unsigned kTargets = 3;
+
+    std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> const cctx{ZSTD_createCCtx(), ZSTD_freeCCtx};
+    FrameReader reader;
+    while (size > 0) {
+        nix::remote::NarFrame frame;
+        // Occasionally out of range on purpose.
+        frame.set_path_index(takeByte(raw, size) % (kTargets + 1));
+        uint8_t const flags = takeByte(raw, size);
+        frame.set_eof((flags & 1U) != 0);
+        size_t const len = std::min<size_t>(takeByte(raw, size), size);
+        auto payload = view(raw, len);
+        raw += len;
+        size -= len;
+        if ((flags & 2U) != 0) {
+            nixgrpc::zstdCompressInto(
+                *cctx,
+                *frame.mutable_data(),
+                {.src = payload.data(), .size = payload.size(), .pos = 0},
+                (flags & 4U) != 0 ? ZSTD_e_end : ZSTD_e_flush,
+                []() -> void {});
+        } else {
+            frame.set_data(std::string(payload));
+        }
+        reader.frames.push_back(std::move(frame));
+    }
+
+    std::vector<std::shared_ptr<nixgrpc::NarSpool>> targets;
+    for (unsigned idx = 0; idx < kTargets; ++idx) {
+        targets.push_back(std::make_shared<nixgrpc::NarSpool>());
+    }
+    try {
+        nixgrpc::demuxNarFrames(reader, targets);
+    } catch (std::exception &) { // NOLINT(bugprone-empty-catch): mirrors NarFetcher::Session::run()
+    }
+    return 0;
+}

--- a/fuzz/support.cc
+++ b/fuzz/support.cc
@@ -1,0 +1,12 @@
+// Linked into every fuzz target.
+
+// libnixstore's readString() allocates whatever 64-bit length the peer sends,
+// so huge allocations are expected; let them fail as std::bad_alloc (which
+// production code catches) instead of an ASan report. scripts/fuzz.sh raises
+// libFuzzer's -malloc_limit_mb to match. DummyStore and libstore globals are
+// never freed, hence no leak check.
+// NOLINTNEXTLINE(bugprone-reserved-identifier,readability-identifier-naming)
+extern "C" auto __asan_default_options() -> const char *
+{
+    return "allocator_may_return_null=1:detect_leaks=0";
+}

--- a/fuzz/support.hh
+++ b/fuzz/support.hh
@@ -1,0 +1,82 @@
+#pragma once
+// Shared helpers for the libFuzzer targets.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include <nix/store/globals.hh>
+#include <nix/store/store-api.hh>
+#include <nix/store/store-open.hh>
+#include <nix/util/logging.hh>
+#include <nix/util/ref.hh>
+
+namespace nixgrpc::fuzz {
+
+// Stands in for a grpc::ServerReader/ClientReader: yields `data` as messages
+// of `chunk` bytes so message-boundary handling is fuzzed too.
+template<class Msg>
+struct ChunkReader
+{
+    std::string_view data;
+    size_t chunk;
+
+    auto Read(Msg * msg) -> bool
+    {
+        if (data.empty()) {
+            return false;
+        }
+        size_t const n = std::min(chunk, data.size());
+        msg->set_data(std::string(data.substr(0, n)));
+        data.remove_prefix(n);
+        return true;
+    }
+};
+
+// Collects everything a ZstdWriterSink ships into one byte string.
+template<class Msg>
+struct CollectWriter
+{
+    std::string out;
+
+    auto Write(const Msg & msg) -> bool
+    {
+        out += msg.data();
+        return true;
+    }
+};
+
+// Splits the first byte off as a parameter and returns the rest.
+inline auto takeByte(const uint8_t *& raw, size_t & size) -> uint8_t
+{
+    if (size == 0) {
+        return 0;
+    }
+    uint8_t const value = *raw;
+    ++raw;
+    --size;
+    return value;
+}
+
+inline auto view(const uint8_t * raw, size_t size) -> std::string_view
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return {reinterpret_cast<const char *>(raw), size};
+}
+
+// In-memory store for the worker-protocol deserialisers, which need a
+// StoreDirConfig to parse store paths.
+inline auto store() -> nix::Store &
+{
+    static nix::ref<nix::Store> const instance = []() -> nix::ref<nix::Store> {
+        nix::initLibStore(false);
+        nix::verbosity = nix::lvlError;
+        return nix::openStore("dummy://");
+    }();
+    return *instance;
+}
+
+} // namespace nixgrpc::fuzz

--- a/fuzz/tunnel-pump.cc
+++ b/fuzz/tunnel-pump.cc
@@ -1,0 +1,27 @@
+// Connect tunnel: pumpStreamToFd decodes client-controlled zstd Chunks into
+// the daemon socket.
+
+#include <cstddef>
+#include <cstdint>
+
+#include <fcntl.h>
+
+#include <nix/util/error.hh>
+#include <nix/util/file-descriptor.hh>
+
+#include "nix_remote.pb.h"
+#include "../src/pump.hh"
+#include "support.hh"
+
+extern "C" auto LLVMFuzzerTestOneInput(const uint8_t * raw, size_t size) -> int
+{
+    using namespace nixgrpc::fuzz;
+    static nix::AutoCloseFD devNull{::open("/dev/null", O_WRONLY | O_CLOEXEC)};
+    ChunkReader<nix::remote::Chunk> reader{.data = {}, .chunk = (takeByte(raw, size) + 1U) * 64U};
+    reader.data = view(raw, size);
+    try {
+        nixgrpc::pumpStreamToFd(reader, devNull.get());
+    } catch (nix::Error &) {
+    }
+    return 0;
+}

--- a/fuzz/wire.cc
+++ b/fuzz/wire.cc
@@ -1,0 +1,79 @@
+// Peer-supplied strings/blobs that go straight into libnixstore parsers. The
+// first byte selects which one, so one corpus covers all of them.
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <string>
+#include <vector>
+
+#include <nix/store/build-result.hh>
+#include <nix/store/derivations.hh>
+#include <nix/store/derived-path.hh>
+#include <nix/store/path.hh>
+#include <nix/store/worker-protocol.hh>
+#include <nix/store/worker-protocol-impl.hh> // IWYU pragma: keep
+#include <nix/util/error.hh>
+#include <nix/util/serialise.hh>
+
+#include "nix_remote.pb.h"
+#include "../src/nix-compat.hh"
+#include "../src/path-info-wire.hh"
+#include "support.hh"
+
+extern "C" auto LLVMFuzzerTestOneInput(const uint8_t * raw, size_t size) -> int
+{
+    using namespace nixgrpc::fuzz;
+    auto & dummy = store();
+    uint8_t const which = takeByte(raw, size) % 6;
+    auto input = view(raw, size);
+    // ReadConn holds the version by reference.
+    auto const version = nixcompat::buildProtocolVersion();
+    auto readConn = [&](nix::Source & source) -> nix::WorkerProto::ReadConn {
+        return nix::WorkerProto::ReadConn{.from = source, .version = version};
+    };
+    try {
+        switch (which) {
+        case 0:
+            // QueryValidPaths/QueryPathInfos/FetchNars requests and replies.
+            static_cast<void>(nix::StorePath(input));
+            break;
+        case 1:
+            // QueryMissing/BuildPaths targets.
+            static_cast<void>(nix::DerivedPath::parse(dummy, input));
+            break;
+        case 2: {
+            // BuildDerivation: drv_path, then drv.
+            auto sep = input.find('\0');
+            nix::StorePath const drvPath(input.substr(0, sep));
+            nix::StringSource source(sep == std::string_view::npos ? "" : input.substr(sep + 1));
+            nix::BasicDerivation drv;
+            nixcompat::readDrv(source, dummy, drv, nix::Derivation::nameFromPath(drvPath));
+            break;
+        }
+        case 3: {
+            // QueryPathInfos reply / build output infos on the client.
+            nix::remote::PathInfo entry;
+            if (entry.ParseFromString(std::string(input))) {
+                static_cast<void>(nixgrpc::decodePathInfo(dummy, entry));
+            }
+            break;
+        }
+        case 4: {
+            nix::StringSource source(input);
+            static_cast<void>(nix::WorkerProto::Serialise<nix::BuildResult>::read(dummy, readConn(source)));
+            break;
+        }
+        case 5: {
+            nix::StringSource source(input);
+            static_cast<void>(
+                nix::WorkerProto::Serialise<std::vector<nix::KeyedBuildResult>>::read(dummy, readConn(source)));
+            break;
+        }
+        default:
+            break;
+        }
+    } catch (std::exception &) { // NOLINT(bugprone-empty-catch): mirrors NixRemoteService::guarded()
+    }
+    return 0;
+}

--- a/fuzz/zstd-reader.cc
+++ b/fuzz/zstd-reader.cc
@@ -1,50 +1,21 @@
 // ZstdReaderSource decodes peer-controlled bytes: it must throw, not crash.
 
-#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <string>
-#include <string_view>
 
 #include <nix/util/error.hh>
 
 #include "nix_remote.pb.h"
 #include "../src/pump.hh"
-
-namespace {
-
-struct FuzzReader
-{
-    std::string_view data;
-    size_t chunk;
-
-    auto Read(nix::remote::Chunk * msg) -> bool
-    {
-        if (data.empty()) {
-            return false;
-        }
-        size_t const n = std::min(chunk, data.size());
-        msg->set_data(std::string(data.substr(0, n)));
-        data.remove_prefix(n);
-        return true;
-    }
-};
-
-} // namespace
+#include "support.hh"
 
 extern "C" auto LLVMFuzzerTestOneInput(const uint8_t * raw, size_t size) -> int
 {
-    if (size < 1) {
-        return 0;
-    }
-    // First byte picks the message size so chunk boundaries are fuzzed too.
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    FuzzReader reader{
-        .data = {reinterpret_cast<const char *>(raw + 1), size - 1},
-        .chunk = static_cast<size_t>(raw[0]) + 1,
-    };
-    nixgrpc::ZstdReaderSource<FuzzReader, nix::remote::Chunk> source(reader, {});
+    using namespace nixgrpc::fuzz;
+    ChunkReader<nix::remote::Chunk> reader{.data = {}, .chunk = takeByte(raw, size) + 1U};
+    reader.data = view(raw, size);
+    nixgrpc::ZstdReaderSource<decltype(reader), nix::remote::Chunk> source(reader, {});
     std::array<char, 4096> buf{};
     try {
         while (true) {

--- a/meson.build
+++ b/meson.build
@@ -115,12 +115,15 @@ executable('nix-grpc-daemon',
 # --- fuzzers ----------------------------------------------------------------
 
 # Built only with -Dfuzzers=true (requires clang for libFuzzer).
+# Run them with scripts/fuzz.sh.
 if get_option('fuzzers')
-  executable('fuzz-zstd-reader',
-    sources : ['fuzz/zstd-reader.cc', gen],
-    include_directories : gen_inc,
-    cpp_args : ['-fsanitize=fuzzer'],
-    link_args : ['-fsanitize=fuzzer'],
-    dependencies : common_deps + [nix_util_dep, nix_store_dep],
-  )
+  foreach name : ['zstd-reader', 'tunnel-pump', 'import-paths', 'build-log', 'nar-frames', 'wire', 'acl']
+    executable('fuzz-' + name,
+      sources : ['fuzz' / name + '.cc', 'fuzz/support.cc', gen],
+      include_directories : gen_inc,
+      cpp_args : nix_compat_args + ['-fsanitize=fuzzer'],
+      link_args : ['-fsanitize=fuzzer'],
+      dependencies : common_deps + [nix_util_dep, nix_store_dep],
+    )
+  endforeach
 endif

--- a/nixos/server.nix
+++ b/nixos/server.nix
@@ -232,6 +232,8 @@ in
           ]
           ++ cfg.extraFlags
         );
+        # Builds run in nix-daemon; this only bounds the proxy.
+        MemoryMax = lib.mkDefault "2G";
         NoNewPrivileges = true;
         ProtectSystem = "strict";
         ProtectHome = true;

--- a/packages.nix
+++ b/packages.nix
@@ -3,6 +3,7 @@
   lib,
   newScope,
   nixVersions,
+  clangStdenv,
   symlinkJoin,
   # Nix package set the default plugin builds against.
   nixPackages,
@@ -25,6 +26,23 @@ lib.makeScope newScope (
     default = self.callPackage ./package.nix {
       inherit (nixPackages) nix-store nix-util;
     };
+
+    # libFuzzer + ASan/UBSan builds of fuzz/*.cc, installed as bin/fuzz-*.
+    fuzzers = (self.default.override { stdenv = clangStdenv; }).overrideAttrs (old: {
+      pname = "nix-grpc-store-fuzzers";
+      mesonFlags = (old.mesonFlags or [ ]) ++ [
+        "-Dfuzzers=true"
+        "-Db_sanitize=address,undefined"
+        "-Db_lundef=false"
+      ];
+      hardeningDisable = [ "fortify" ];
+      installPhase = ''
+        mkdir -p $out/bin
+        find . -maxdepth 1 -type f -name 'fuzz-*' -exec install -m755 -t $out/bin/ {} +
+      '';
+      doCheck = false;
+      dontFixup = true;
+    });
 
     # One plugin per supported Nix release. nixVersions.git is `default`.
     versionPlugins = lib.listToAttrs (

--- a/packages.nix
+++ b/packages.nix
@@ -44,6 +44,15 @@ lib.makeScope newScope (
       dontFixup = true;
     });
 
+    # Same targets with source coverage, for scripts/fuzz.sh -c.
+    fuzzers-coverage = self.fuzzers.overrideAttrs (old: {
+      pname = "nix-grpc-store-fuzzers-coverage";
+      env = old.env // {
+        NIX_CFLAGS_COMPILE = old.env.NIX_CFLAGS_COMPILE + " -fprofile-instr-generate -fcoverage-mapping";
+        NIX_CFLAGS_LINK = "-fprofile-instr-generate";
+      };
+    });
+
     # One plugin per supported Nix release. nixVersions.git is `default`.
     versionPlugins = lib.listToAttrs (
       map (

--- a/patches/nix-readstring-no-prealloc.patch
+++ b/patches/nix-readstring-no-prealloc.patch
@@ -1,0 +1,80 @@
+From e8714b209a443b79028c0a0a5b9e399d495cb66d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Mon, 31 Aug 2026 10:35:28 +0200
+Subject: [PATCH] readString: do not preallocate the announced length
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A bogus 64-bit length prefix made readString() allocate and zero that
+much memory before reading any payload. Grow the buffer as data arrives
+instead.
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ src/libutil-tests/serialise.cc | 25 +++++++++++++++++++++++++
+ src/libutil/serialise.cc       | 12 ++++++++++--
+ 2 files changed, 35 insertions(+), 2 deletions(-)
+
+diff --git a/src/libutil-tests/serialise.cc b/src/libutil-tests/serialise.cc
+index 40424c685..4498fb2aa 100644
+--- a/src/libutil-tests/serialise.cc
++++ b/src/libutil-tests/serialise.cc
+@@ -24,6 +24,31 @@ TEST(readNum, negativeValuesSerialiseWellDefined)
+     EXPECT_EQ(readNum<uint64_t>(*makeNumSource(int16_t(-1))), std::numeric_limits<uint64_t>::max());
+ }
+ 
++TEST(readString, roundTrip)
++{
++    for (auto s : {"", "x", "1234567", "12345678", "123456789"}) {
++        StringSink sink;
++        sink << std::string_view(s);
++        StringSource source(sink.s);
++        EXPECT_EQ(readString(source), s);
++    }
++    std::string big(300'000, 'a');
++    StringSink sink;
++    sink << big;
++    StringSource source(sink.s);
++    EXPECT_EQ(readString(source), big);
++}
++
++TEST(readString, bogusLengthDoesNotPreallocate)
++{
++    // 1 TiB length prefix followed by EOF: must fail on the read, not by
++    // allocating (and zeroing) the announced size up front.
++    StringSink sink;
++    sink << (uint64_t(1) << 40);
++    StringSource source(sink.s);
++    EXPECT_THROW(readString(source), EndOfFile);
++}
++
+ TEST(readPadding, works)
+ {
+     for (unsigned i = 0; i < 8; ++i)
+diff --git a/src/libutil/serialise.cc b/src/libutil/serialise.cc
+index eb1209843..8d5b3e6d5 100644
+--- a/src/libutil/serialise.cc
++++ b/src/libutil/serialise.cc
+@@ -600,8 +600,16 @@ std::string readString(Source & source, size_t max)
+     auto len = readNum<size_t>(source);
+     if (len > max)
+         throw SerialisationError("string is too long");
+-    std::string res(len, 0);
+-    source(res.data(), len);
++    /* Grow with the data actually received rather than trusting `len` for
++       the allocation, so a bogus length prefix costs the peer as many bytes
++       as it costs us. */
++    std::string res;
++    size_t filled = 0;
++    while (filled < len) {
++        if (filled == res.size())
++            res.resize(std::min(len, std::max<size_t>(2 * res.size(), 64 * 1024)));
++        filled += source.read(res.data() + filled, res.size() - filled);
++    }
+     readPadding(len, source);
+     return res;
+ }
+-- 
+2.55.0
+

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -5,27 +5,47 @@
 #   scripts/fuzz.sh                 # every target, 60 s each
 #   scripts/fuzz.sh -t 600 wire     # one target, 10 min
 #   scripts/fuzz.sh -j 8            # 8 libFuzzer workers per target
+#   scripts/fuzz.sh -c              # replay corpus, print line coverage of src/
 set -euo pipefail
 
 seconds=60
 jobs=1
-while getopts "t:j:" opt; do
+coverage=0
+while getopts "t:j:c" opt; do
   case "$opt" in
     t) seconds=$OPTARG ;;
     j) jobs=$OPTARG ;;
-    *) echo "usage: $0 [-t seconds] [-j jobs] [target...]" >&2; exit 1 ;;
+    c) coverage=1 ;;
+    *) echo "usage: $0 [-t seconds] [-j jobs] [-c] [target...]" >&2; exit 1 ;;
   esac
 done
 shift $((OPTIND - 1))
 
 root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-bin=$(nix build --no-link --print-out-paths "$root#fuzzers")/bin
+attr=fuzzers
+[[ $coverage -eq 1 ]] && attr=fuzzers-coverage
+bin=$(nix build --no-link --print-out-paths "$root#$attr")/bin
 corpusRoot=${XDG_CACHE_HOME:-$HOME/.cache}/nix-grpc-store/fuzz
 
 if [[ $# -eq 0 ]]; then
   mapfile -t targets < <(cd "$bin" && printf '%s\n' fuzz-* | sed 's/^fuzz-//')
 else
   targets=("$@")
+fi
+
+if [[ $coverage -eq 1 ]]; then
+  profdir=$(mktemp -d)
+  trap 'rm -rf "$profdir"' EXIT
+  objects=()
+  for target in "${targets[@]}"; do
+    LLVM_PROFILE_FILE="$profdir/$target.profraw" "$bin/fuzz-$target" -runs=0 "$corpusRoot/$target" >/dev/null 2>&1
+    objects+=(-object "$bin/fuzz-$target")
+  done
+  llvm=(nix shell --inputs-from "$root" nixpkgs#llvmPackages.llvm -c)
+  "${llvm[@]}" llvm-profdata merge -o "$profdir/merged.profdata" "$profdir"/*.profraw
+  "${llvm[@]}" llvm-cov report "${objects[@]:1}" -instr-profile="$profdir/merged.profdata" \
+    -ignore-filename-regex='(nix_remote\..*pb|/nix/store/|fuzz/)'
+  exit 0
 fi
 
 status=0

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Build the libFuzzer targets and run each one against a persistent corpus
+# under $XDG_CACHE_HOME/nix-grpc-store/fuzz/<target>.
+#
+#   scripts/fuzz.sh                 # every target, 60 s each
+#   scripts/fuzz.sh -t 600 wire     # one target, 10 min
+#   scripts/fuzz.sh -j 8            # 8 libFuzzer workers per target
+set -euo pipefail
+
+seconds=60
+jobs=1
+while getopts "t:j:" opt; do
+  case "$opt" in
+    t) seconds=$OPTARG ;;
+    j) jobs=$OPTARG ;;
+    *) echo "usage: $0 [-t seconds] [-j jobs] [target...]" >&2; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+bin=$(nix build --no-link --print-out-paths "$root#fuzzers")/bin
+corpusRoot=${XDG_CACHE_HOME:-$HOME/.cache}/nix-grpc-store/fuzz
+
+if [[ $# -eq 0 ]]; then
+  mapfile -t targets < <(cd "$bin" && printf '%s\n' fuzz-* | sed 's/^fuzz-//')
+else
+  targets=("$@")
+fi
+
+status=0
+for target in "${targets[@]}"; do
+  corpus=$corpusRoot/$target
+  artifacts=$corpusRoot/$target-artifacts/
+  mkdir -p "$corpus" "$artifacts"
+  echo "==> fuzz-$target (${seconds}s, corpus: $corpus)"
+  if ! "$bin/fuzz-$target" \
+      -max_total_time="$seconds" \
+      -jobs="$jobs" -workers="$jobs" \
+      -rss_limit_mb=4096 -malloc_limit_mb=1000000 \
+      -max_len=65536 \
+      -artifact_prefix="$artifacts" \
+      "$corpus"; then
+    echo "!!  fuzz-$target failed, reproducers in $artifacts" >&2
+    status=1
+  fi
+done
+exit "$status"

--- a/src/build-log.hh
+++ b/src/build-log.hh
@@ -1,0 +1,80 @@
+#pragma once
+// Parser for the worker-protocol stderr stream the backend nix-daemon sends
+// around each operation. Shared between the daemon's build RPCs and the fuzzer.
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nix/store/worker-protocol.hh>
+#include <nix/util/error.hh>
+#include <nix/util/logging.hh>
+#include <nix/util/serialise.hh>
+#include <nix/util/util.hh>
+
+namespace nixgrpc {
+
+// nix::readString() preallocates the announced length.
+constexpr size_t kMaxLogString = 1UL << 20;
+
+namespace detail {
+
+inline auto readLogFields(nix::Source & source) -> std::vector<std::string>
+{
+    std::vector<std::string> fields;
+    auto count = nix::readNum<uint64_t>(source);
+    for (uint64_t idx = 0; idx < count; ++idx) {
+        auto type = nix::readNum<uint64_t>(source);
+        if (type == 0) {
+            nix::readNum<uint64_t>(source);
+            fields.emplace_back();
+        } else if (type == 1) {
+            fields.push_back(nix::readString(source, kMaxLogString));
+        } else {
+            throw nix::Error("unknown logger field type %d from backend", type);
+        }
+    }
+    return fields;
+}
+
+} // namespace detail
+
+// Consumes the stream up to STDERR_LAST, forwarding plain build log lines.
+// Throws the daemon's error on STDERR_ERROR.
+inline void relayBuildLog(nix::Source & source, const std::function<void(std::string)> & sendLogLine)
+{
+    while (true) {
+        auto msg = nix::readNum<uint64_t>(source);
+        if (msg == STDERR_NEXT) {
+            sendLogLine(nix::chomp(nix::readString(source, kMaxLogString)));
+        } else if (msg == STDERR_START_ACTIVITY) {
+            nix::readNum<uint64_t>(source); // id
+            nix::readNum<uint64_t>(source); // level
+            nix::readNum<uint64_t>(source); // type
+            nix::readString(source, kMaxLogString); // text
+            detail::readLogFields(source);
+            nix::readNum<uint64_t>(source); // parent
+        } else if (msg == STDERR_STOP_ACTIVITY) {
+            nix::readNum<uint64_t>(source);
+        } else if (msg == STDERR_RESULT) {
+            nix::readNum<uint64_t>(source); // id
+            auto type = nix::readNum<uint64_t>(source);
+            auto fields = detail::readLogFields(source);
+            if (type == nix::resBuildLogLine && !fields.empty()) {
+                sendLogLine(std::move(fields.front()));
+            }
+        } else if (msg == STDERR_ERROR) {
+            throw nix::readError(source);
+        } else if (msg == STDERR_LAST) {
+            break;
+        } else {
+            // STDERR_READ/WRITE need a tunnel we do not provide.
+            throw nix::Error("unexpected worker protocol message 0x%x from backend", msg);
+        }
+    }
+}
+
+} // namespace nixgrpc

--- a/src/grpc-store.cc
+++ b/src/grpc-store.cc
@@ -66,6 +66,7 @@
 
 #include "nix-compat.hh"
 #include "nar-fetcher.hh"
+#include "path-info-wire.hh"
 #include "nix_remote.grpc.pb.h"
 #include "nix_remote.pb.h"
 #include "pump.hh"
@@ -567,7 +568,7 @@ public:
               *this, WorkerProto::ReadConn{.from = source,
                                            .version = nixcompat::buildProtocolVersion()});
           for (const auto & entry : msg.done().outputs()) {
-            infos.insert(parseInfoEntry(entry));
+            infos.insert(nixgrpc::decodePathInfo(*this, entry));
           }
         }
       }
@@ -610,7 +611,7 @@ public:
               *this, WorkerProto::ReadConn{.from = source,
                                            .version = nixcompat::buildProtocolVersion()});
           for (const auto & entry : msg.done().outputs()) {
-            infos.insert(parseInfoEntry(entry));
+            infos.insert(nixgrpc::decodePathInfo(*this, entry));
           }
         }
       }
@@ -658,17 +659,6 @@ public:
 private:
     using PathInfoMap = std::map<StorePath, std::shared_ptr<const ValidPathInfo>>;
 
-    auto parseInfoEntry(const remote::PathInfo & entry)
-        -> std::pair<StorePath, std::shared_ptr<const ValidPathInfo>> {
-      StorePath const path(entry.path());
-      StringSource source(entry.info());
-      auto info = WorkerProto::Serialise<UnkeyedValidPathInfo>::read(
-          *this, WorkerProto::ReadConn{.from = source,
-                                       .version = nixcompat::infoProtocolVersion()});
-      return {path, std::make_shared<ValidPathInfo>(StorePath(path),
-                                                    std::move(info))};
-    }
-
     std::once_flag trustedOnce;
     std::optional<TrustedFlag> trusted;
 
@@ -690,7 +680,7 @@ private:
 
       PathInfoMap res;
       for (const auto &entry : reply.infos()) {
-        res.insert(parseInfoEntry(entry));
+        res.insert(nixgrpc::decodePathInfo(*this, entry));
       }
       return res;
     }

--- a/src/import-paths.hh
+++ b/src/import-paths.hh
@@ -1,0 +1,44 @@
+#pragma once
+// Body framing of the AddMultipleToStore RPC (after zstd), shared between the
+// daemon handler and its fuzzer.
+
+#include <cstdint>
+
+#include <nix/store/path-info.hh>
+#include <nix/store/store-dir-config.hh>
+#include <nix/store/worker-protocol.hh>
+#include <nix/util/serialise.hh>
+
+#include "nix-compat.hh"
+
+namespace nixgrpc {
+
+struct ImportStats
+{
+    uint64_t paths = 0;
+    uint64_t narBytes = 0;
+};
+
+// Same framing as nix::WorkerProto::Op::AddMultipleToStore: a count, then per
+// path a ValidPathInfo (protocol 1.16) followed by narSize NAR bytes. `addOne`
+// receives the info and a Source positioned at the NAR; whatever it leaves
+// unread up to narSize is skipped.
+template<class Fn>
+inline auto importPaths(const nix::StoreDirConfig & store, nix::Source & source, const Fn & addOne) -> ImportStats
+{
+    ImportStats stats;
+    auto const expected = nix::readNum<uint64_t>(source);
+    for (uint64_t idx = 0; idx < expected; ++idx) {
+        auto info = nix::WorkerProto::Serialise<nix::ValidPathInfo>::read(
+            store, nix::WorkerProto::ReadConn{.from = source, .version = nixcompat::infoProtocolVersion()});
+        info.ultimate = false;
+        nixcompat::EnsureRead wrapper{source, info.narSize};
+        addOne(info, static_cast<nix::Source &>(wrapper));
+        wrapper.finish();
+        stats.narBytes += info.narSize;
+        ++stats.paths;
+    }
+    return stats;
+}
+
+} // namespace nixgrpc

--- a/src/nar-fetcher.hh
+++ b/src/nar-fetcher.hh
@@ -22,6 +22,7 @@
 #include <nix/store/path.hh>
 #include <nix/util/error.hh>
 #include <nix/util/file-descriptor.hh>
+#include <nix/util/file-system.hh>
 #include <nix/util/serialise.hh>
 #include <nix/util/util.hh>
 #include <string>
@@ -37,6 +38,133 @@
 #include "pump.hh"
 
 namespace nixgrpc {
+
+// Unlinked temp file one reader thread appends to while fetchInto() streams
+// it out, so a large NAR never has to fit in memory.
+class NarSpool
+{
+    nix::AutoCloseFD fd;
+    std::mutex mutex;
+    std::condition_variable grown;
+    uint64_t written = 0;
+    bool eof = false;
+    std::exception_ptr failure;
+
+public:
+    NarSpool()
+    {
+        auto [tmpFd, tmpPath] = nix::createTempFile("nix-grpc-nar");
+        ::unlink(tmpPath.c_str());
+        fd = std::move(tmpFd);
+    }
+
+    void append(std::string_view data)
+    {
+        auto const size = data.size();
+        uint64_t off = written;
+        if (eof) {
+            throw nix::Error("gRPC FetchNars sent data after EOF for a path");
+        }
+        while (!data.empty()) {
+            auto count = ::pwrite(fd.get(), data.data(), data.size(), static_cast<off_t>(off));
+            if (count < 0) {
+                throw nix::SysError("writing NAR spool file");
+            }
+            data.remove_prefix(static_cast<size_t>(count));
+            off += static_cast<uint64_t>(count);
+        }
+        {
+            std::scoped_lock const lock(mutex);
+            written += size;
+        }
+        grown.notify_all();
+    }
+
+    void finish()
+    {
+        {
+            std::scoped_lock const lock(mutex);
+            if (eof) {
+                throw nix::Error("gRPC FetchNars sent duplicate EOF for a path");
+            }
+            eof = true;
+        }
+        grown.notify_all();
+    }
+
+    void fail(const std::exception_ptr & cause)
+    {
+        {
+            std::scoped_lock const lock(mutex);
+            if (eof || failure) {
+                return;
+            }
+            failure = cause;
+        }
+        grown.notify_all();
+    }
+
+    void readInto(nix::Sink & sink)
+    {
+        uint64_t pos = 0;
+        std::vector<char> buf(kChunkSize);
+        while (true) {
+            uint64_t avail = 0;
+            {
+                std::unique_lock lock(mutex);
+                grown.wait(lock, [&] -> bool { return written > pos || eof || failure; });
+                if (failure) {
+                    std::rethrow_exception(failure);
+                }
+                avail = written;
+                if (avail == pos && eof) {
+                    fd.close();
+                    return;
+                }
+            }
+            while (pos < avail) {
+                auto want = std::min<uint64_t>(buf.size(), avail - pos);
+                auto count = ::pread(fd.get(), buf.data(), want, static_cast<off_t>(pos));
+                if (count <= 0) {
+                    throw nix::SysError("reading NAR spool file");
+                }
+                sink({buf.data(), static_cast<size_t>(count)});
+                pos += static_cast<uint64_t>(count);
+            }
+        }
+    }
+};
+
+// Decode one FetchNars stream (server-controlled path_index/data/eof) into
+// the per-path spools. Throws on malformed input; the caller fails all
+// targets.
+template<class Reader>
+inline void demuxNarFrames(Reader & reader, const std::vector<std::shared_ptr<NarSpool>> & targets)
+{
+    std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> const dctx{ZSTD_createDCtx(), ZSTD_freeDCtx};
+    std::string out(ZSTD_DStreamOutSize(), '\0');
+    nix::remote::NarFrame frame;
+    while (reader.Read(&frame)) {
+        if (frame.path_index() >= targets.size()) {
+            throw nix::Error("gRPC FetchNars sent path index %d for %d requested paths", frame.path_index(), targets.size());
+        }
+        const auto & target = targets.at(frame.path_index());
+        ZSTD_inBuffer zin{.src = frame.data().data(), .size = frame.data().size(), .pos = 0};
+        while (true) {
+            ZSTD_outBuffer zout{.dst = out.data(), .size = out.size(), .pos = 0};
+            zstdCheck(ZSTD_decompressStream(dctx.get(), &zout, &zin), "decompress");
+            if (zout.pos != 0) {
+                target->append({out.data(), zout.pos});
+            }
+            if (zin.pos == zin.size && zout.pos < zout.size) {
+                break;
+            }
+        }
+        if (frame.eof()) {
+            target->finish();
+        }
+    }
+}
 
 class NarFetcher
 {
@@ -69,7 +197,7 @@ public:
 
     void fetchInto(const nix::StorePath & path, nix::Sink & sink)
     {
-        std::shared_ptr<SpoolBuffer> buffer;
+        std::shared_ptr<NarSpool> buffer;
         {
             std::scoped_lock const lock(narMutex);
             auto found = buffers.find(path);
@@ -104,94 +232,6 @@ public:
     }
 
 private:
-    class SpoolBuffer
-    {
-        nix::AutoCloseFD fd;
-        std::mutex mutex;
-        std::condition_variable grown;
-        uint64_t written = 0;
-        bool eof = false;
-        std::exception_ptr failure;
-
-    public:
-        SpoolBuffer()
-        {
-            auto [tmpFd, tmpPath] = nix::createTempFile("nix-grpc-nar");
-            ::unlink(tmpPath.c_str());
-            fd = std::move(tmpFd);
-        }
-
-        void append(std::string_view data)
-        {
-            auto const size = data.size();
-            uint64_t off = written;
-            while (!data.empty()) {
-                auto count = ::pwrite(fd.get(), data.data(), data.size(), static_cast<off_t>(off));
-                if (count < 0) {
-                    throw nix::SysError("writing NAR spool file");
-                }
-                data.remove_prefix(static_cast<size_t>(count));
-                off += static_cast<uint64_t>(count);
-            }
-            {
-                std::scoped_lock const lock(mutex);
-                written += size;
-            }
-            grown.notify_all();
-        }
-
-        void finish()
-        {
-            {
-                std::scoped_lock const lock(mutex);
-                eof = true;
-            }
-            grown.notify_all();
-        }
-
-        void fail(const std::exception_ptr & cause)
-        {
-            {
-                std::scoped_lock const lock(mutex);
-                if (eof || failure) {
-                    return;
-                }
-                failure = cause;
-            }
-            grown.notify_all();
-        }
-
-        void readInto(nix::Sink & sink)
-        {
-            uint64_t pos = 0;
-            std::vector<char> buf(kChunkSize);
-            while (true) {
-                uint64_t avail = 0;
-                {
-                    std::unique_lock lock(mutex);
-                    grown.wait(lock, [&] -> bool { return written > pos || eof || failure; });
-                    if (failure) {
-                        std::rethrow_exception(failure);
-                    }
-                    avail = written;
-                    if (avail == pos && eof) {
-                        fd.close();
-                        return;
-                    }
-                }
-                while (pos < avail) {
-                    auto want = std::min<uint64_t>(buf.size(), avail - pos);
-                    auto count = ::pread(fd.get(), buf.data(), want, static_cast<off_t>(pos));
-                    if (count <= 0) {
-                        throw nix::SysError("reading NAR spool file");
-                    }
-                    sink({buf.data(), static_cast<size_t>(count)});
-                    pos += static_cast<uint64_t>(count);
-                }
-            }
-        }
-    };
-
     class Session
     {
         friend class NarFetcher;
@@ -199,32 +239,13 @@ private:
         std::unique_ptr<nix::remote::NixRemote::Stub> stub;
         grpc::ClientContext ctx;
         std::unique_ptr<grpc::ClientReader<nix::remote::NarFrame>> reader;
-        std::vector<std::shared_ptr<SpoolBuffer>> targets;
-        std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> dctx{ZSTD_createDCtx(), ZSTD_freeDCtx};
+        std::vector<std::shared_ptr<NarSpool>> targets;
         std::thread thread;
 
         void run()
         {
             try {
-                std::string out(ZSTD_DStreamOutSize(), '\0');
-                nix::remote::NarFrame frame;
-                while (reader->Read(&frame)) {
-                    auto & target = targets.at(frame.path_index());
-                    ZSTD_inBuffer zin{.src = frame.data().data(), .size = frame.data().size(), .pos = 0};
-                    while (true) {
-                        ZSTD_outBuffer zout{.dst = out.data(), .size = out.size(), .pos = 0};
-                        zstdCheck(ZSTD_decompressStream(dctx.get(), &zout, &zin), "decompress");
-                        if (zout.pos != 0) {
-                            target->append({out.data(), zout.pos});
-                        }
-                        if (zin.pos == zin.size && zout.pos < zout.size) {
-                            break;
-                        }
-                    }
-                    if (frame.eof()) {
-                        target->finish();
-                    }
-                }
+                demuxNarFrames(*reader, targets);
                 auto status = reader->Finish();
                 auto cause = std::make_exception_ptr(
                     status.ok() ? nix::Error("gRPC FetchNars stream ended early")
@@ -246,7 +267,7 @@ private:
 
     std::mutex narMutex;
     std::vector<std::unique_ptr<Session>> sessions;
-    std::map<nix::StorePath, std::shared_ptr<SpoolBuffer>> buffers;
+    std::map<nix::StorePath, std::shared_ptr<NarSpool>> buffers;
     std::vector<nix::StorePath> pending;
     std::map<nix::StorePath, uint64_t> narSizes;
 
@@ -289,7 +310,7 @@ private:
         nix::remote::FetchNarsRequest request;
         for (const auto & path : paths) {
             request.add_paths(std::string(path.to_string()));
-            auto buffer = std::make_shared<SpoolBuffer>();
+            auto buffer = std::make_shared<NarSpool>();
             session->targets.push_back(buffer);
             buffers.emplace(path, std::move(buffer));
         }

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -38,7 +38,6 @@
 #include <nix/store/build-result.hh>
 #include <nix/store/derivations.hh>
 #include <nix/store/globals.hh>
-#include <nix/util/logging.hh>
 #include <nix/store/worker-protocol-connection.hh>
 #include <nix/store/path-info.hh>
 #include <nix/store/path.hh>
@@ -58,7 +57,10 @@
 #include <nix/util/util.hh>
 
 #include "acl.hh"
+#include "build-log.hh"
+#include "import-paths.hh"
 #include "logfmt.hh"
+#include "path-info-wire.hh"
 #include "metrics.hh"
 #include "nix-compat.hh"
 #include "nix_remote.grpc.pb.h"
@@ -289,19 +291,10 @@ public:
             nixgrpc::ZstdReaderSource<AddMultipleReader, nix::remote::AddMultipleChunk> source(
                 *reader, std::move(*first.mutable_data()));
 
-            // Same framing as nix::WorkerProto::Op::AddMultipleToStore.
-            auto expected = nix::readNum<uint64_t>(source);
-            uint64_t narBytes = 0;
-            for (uint64_t idx = 0; idx < expected; ++idx) {
-                auto info = nix::WorkerProto::Serialise<nix::ValidPathInfo>::read(
-                    *localStore,
-                    nix::WorkerProto::ReadConn{.from = source, .version = nixcompat::infoProtocolVersion()});
-                info.ultimate = false;
-                nixcompat::EnsureRead wrapper{source, info.narSize};
-                localStore->addToStore(info, wrapper, repair, checkSigs);
-                wrapper.finish();
-                narBytes += info.narSize;
-            }
+            auto stats = nixgrpc::importPaths(
+                *localStore, source, [&](const nix::ValidPathInfo & info, nix::Source & nar) -> void {
+                    localStore->addToStore(info, nar, repair, checkSigs);
+                });
             nixgrpc::logLine(
                 nixgrpc::LogLevel::info,
                 {{"event", "rpc"},
@@ -309,10 +302,10 @@ public:
                  {"cn", commonName},
                  {"peer", peer},
                  {"duration_s", secondsSince(start)},
-                 {"paths", std::to_string(expected)},
-                 {"nar_bytes_in", std::to_string(narBytes)}});
+                 {"paths", std::to_string(stats.paths)},
+                 {"nar_bytes_in", std::to_string(stats.narBytes)}});
             metrics.countRpc("AddMultipleToStore", commonName);
-            metrics.countNarBytes("in", commonName, narBytes);
+            metrics.countNarBytes("in", commonName, stats.narBytes);
             return grpc::Status::OK;
         });
     }
@@ -343,14 +336,7 @@ public:
                 } catch (nix::InvalidPath &) {
                     continue;
                 }
-                auto * out = reply->add_infos();
-                out->set_path(std::string(info->path.to_string()));
-                nix::StringSink sink;
-                nix::WorkerProto::Serialise<nix::UnkeyedValidPathInfo>::write(
-                    *localStore,
-                    nix::WorkerProto::WriteConn{.to = sink, .version = nixcompat::infoProtocolVersion()},
-                    static_cast<const nix::UnkeyedValidPathInfo &>(*info));
-                *out->mutable_info() = std::move(sink.s);
+                nixgrpc::encodePathInfo(*localStore, *info, reply->add_infos());
             }
             return grpc::Status::OK;
         });
@@ -442,63 +428,9 @@ public:
         });
     }
 
-    // Consumes the worker-protocol stderr stream up to STDERR_LAST,
-    // forwarding plain build log lines.
     static void appendOutputInfo(nix::Store & store, nix::remote::PathInfo * out, const nix::StorePath & outPath)
     {
-        auto info = store.queryPathInfo(outPath);
-        out->set_path(std::string(info->path.to_string()));
-        nix::StringSink sink;
-        nix::WorkerProto::Serialise<nix::UnkeyedValidPathInfo>::write(
-            store,
-            nix::WorkerProto::WriteConn{.to = sink, .version = nixcompat::infoProtocolVersion()},
-            static_cast<const nix::UnkeyedValidPathInfo &>(*info));
-        *out->mutable_info() = std::move(sink.s);
-    }
-
-    static void relayBuildLog(nix::Source & source, const std::function<void(std::string)> & sendLogLine)
-    {
-        auto readLogFields = [&]() -> std::vector<std::string> {
-            std::vector<std::string> fields;
-            auto count = nix::readNum<uint64_t>(source);
-            for (uint64_t idx = 0; idx < count; ++idx) {
-                if (nix::readNum<uint64_t>(source) == 0) {
-                    nix::readNum<uint64_t>(source);
-                    fields.emplace_back();
-                } else {
-                    fields.push_back(nix::readString(source));
-                }
-            }
-            return fields;
-        };
-        while (true) {
-            auto msg = nix::readNum<uint64_t>(source);
-            if (msg == STDERR_NEXT) {
-                sendLogLine(nix::chomp(nix::readString(source)));
-            } else if (msg == STDERR_START_ACTIVITY) {
-                nix::readNum<uint64_t>(source);
-                nix::readNum<uint64_t>(source);
-                nix::readNum<uint64_t>(source);
-                nix::readString(source);
-                readLogFields();
-                nix::readNum<uint64_t>(source);
-            } else if (msg == STDERR_STOP_ACTIVITY) {
-                nix::readNum<uint64_t>(source);
-            } else if (msg == STDERR_RESULT) {
-                nix::readNum<uint64_t>(source);
-                auto type = nix::readNum<uint64_t>(source);
-                auto fields = readLogFields();
-                if (type == nix::resBuildLogLine && !fields.empty()) {
-                    sendLogLine(std::move(fields.front()));
-                }
-            } else if (msg == STDERR_ERROR) {
-                throw nix::readError(source);
-            } else if (msg == STDERR_LAST) {
-                break;
-            } else {
-                throw nix::Error("unexpected worker protocol message from backend");
-            }
-        }
+        nixgrpc::encodePathInfo(store, *store.queryPathInfo(outPath), out);
     }
 
     auto BuildDerivation(
@@ -534,7 +466,7 @@ public:
                 writer->Write(chunk);
             };
             // The daemon opens every connection with a stderr work block.
-            relayBuildLog(conn.from, sendLogLine);
+            nixgrpc::relayBuildLog(conn.from, sendLogLine);
 
             nix::StorePath const drvPath(request->drv_path());
             nix::StringSource drvSource(request->drv());
@@ -549,7 +481,7 @@ public:
                 static_cast<nix::BuildMode>(request->build_mode()));
             conn.to.flush();
 
-            relayBuildLog(conn.from, sendLogLine);
+            nixgrpc::relayBuildLog(conn.from, sendLogLine);
 
             auto res = nix::WorkerProto::Serialise<nix::BuildResult>::read(
                 *localStore, nix::WorkerProto::ReadConn{.from = conn.from, .version = protocol});
@@ -623,7 +555,7 @@ public:
                 writer->Write(chunk);
             };
             // The daemon opens every connection with a stderr work block.
-            relayBuildLog(conn.from, sendLogLine);
+            nixgrpc::relayBuildLog(conn.from, sendLogLine);
 
             conn.to << nix::WorkerProto::Op::BuildPathsWithResults;
             nix::WorkerProto::write(
@@ -633,7 +565,7 @@ public:
             conn.to << request->build_mode();
             conn.to.flush();
 
-            relayBuildLog(conn.from, sendLogLine);
+            nixgrpc::relayBuildLog(conn.from, sendLogLine);
 
             auto results = nix::WorkerProto::Serialise<std::vector<nix::KeyedBuildResult>>::read(
                 *localStore, nix::WorkerProto::ReadConn{.from = conn.from, .version = protocol});

--- a/src/path-info-wire.hh
+++ b/src/path-info-wire.hh
@@ -1,0 +1,43 @@
+#pragma once
+// (De)serialisation of remote::PathInfo, which carries a store path plus the
+// worker-protocol 1.16 UnkeyedValidPathInfo bytes. Server encodes, client
+// decodes; both live here so the fuzzer exercises the exact client code.
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <nix/store/path-info.hh>
+#include <nix/store/path.hh>
+#include <nix/store/store-dir-config.hh>
+#include <nix/store/worker-protocol.hh>
+#include <nix/util/serialise.hh>
+
+#include "nix-compat.hh"
+#include "nix_remote.pb.h"
+
+namespace nixgrpc {
+
+inline void encodePathInfo(const nix::StoreDirConfig & store, const nix::ValidPathInfo & info, nix::remote::PathInfo * out)
+{
+    out->set_path(std::string(info.path.to_string()));
+    nix::StringSink sink;
+    nix::WorkerProto::Serialise<nix::UnkeyedValidPathInfo>::write(
+        store,
+        nix::WorkerProto::WriteConn{.to = sink, .version = nixcompat::infoProtocolVersion()},
+        static_cast<const nix::UnkeyedValidPathInfo &>(info));
+    *out->mutable_info() = std::move(sink.s);
+}
+
+inline auto decodePathInfo(const nix::StoreDirConfig & store, const nix::remote::PathInfo & entry)
+    -> std::pair<nix::StorePath, std::shared_ptr<const nix::ValidPathInfo>>
+{
+    nix::StorePath path(entry.path());
+    nix::StringSource source(entry.info());
+    auto info = nix::WorkerProto::Serialise<nix::UnkeyedValidPathInfo>::read(
+        store, nix::WorkerProto::ReadConn{.from = source, .version = nixcompat::infoProtocolVersion()});
+    auto full = std::make_shared<const nix::ValidPathInfo>(path, std::move(info));
+    return {std::move(path), std::move(full)};
+}
+
+} // namespace nixgrpc


### PR DESCRIPTION
Only ZstdReaderSource was fuzzed. Add targets for the tunnel decoder, AddMultipleToStore framing, stderr relay, FetchNars demux, the PathInfo/BuildResult/drv decoders and ACL/logfmt, extracting the inline parsers into headers so they are reachable without a server.

This found nix::readString() preallocating the announced length; carry the upstream fix (NixOS/nix#16398) as a patch until merged.