### PR TITLE
daemon: sd_notify readiness and watchdog

### DIFF
--- a/nixos/server.nix
+++ b/nixos/server.nix
@@ -212,6 +212,8 @@ in
       ];
       wants = [ "nix-daemon.socket" ];
       serviceConfig = {
+        Type = "notify";
+        WatchdogSec = 30;
         User = "nix-grpc-daemon";
         Group = "nix-grpc-daemon";
         Restart = "on-failure";

--- a/src/grpc-store.cc
+++ b/src/grpc-store.cc
@@ -18,6 +18,7 @@
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/support/channel_arguments.h>
 #include <grpcpp/support/status.h>
+#include <atomic>
 #include <condition_variable>
 #include <map>
 #include <memory>
@@ -44,6 +45,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <stop_token>
 #include <thread>
 #include <unistd.h>
 #include <variant>
@@ -717,19 +719,17 @@ private:
        BFS level costs one round trip instead of one per path. */
     using InfoCallback = Callback<std::shared_ptr<const ValidPathInfo>>;
     std::mutex infoBatchMutex;
-    std::condition_variable infoBatchWakeup;
+    std::condition_variable_any infoBatchWakeup;
     std::vector<std::pair<StorePath, InfoCallback>> infoBatch;
-    std::thread infoBatchWorker;
-    bool infoBatchStop = false;
+    std::jthread infoBatchWorker;
 
-    void runInfoBatches()
+    void runInfoBatches(const std::stop_token & stop)
     {
         while (true) {
             std::vector<std::pair<StorePath, InfoCallback>> batch;
             {
                 std::unique_lock lock(infoBatchMutex);
-                infoBatchWakeup.wait(lock, [&] -> bool { return infoBatchStop || !infoBatch.empty(); });
-                if (infoBatchStop) {
+                if (!infoBatchWakeup.wait(lock, stop, [&] -> bool { return !infoBatch.empty(); })) {
                     return;
                 }
                 batch.swap(infoBatch);
@@ -771,7 +771,7 @@ public:
               std::scoped_lock const lock(infoBatchMutex);
               infoBatch.emplace_back(path, std::move(callback));
               if (!infoBatchWorker.joinable()) {
-                infoBatchWorker = std::thread([this] -> void { runInfoBatches(); });
+                infoBatchWorker = std::jthread([this](const std::stop_token & stop) -> void { runInfoBatches(stop); });
               }
             }
             infoBatchWakeup.notify_one();
@@ -796,9 +796,9 @@ private:
         Pipe toRemote;   // plugin writes → reader thread sends over gRPC
         Pipe fromRemote; // writer thread receives from gRPC → plugin reads
 
-        std::thread reader;
-        std::thread writer;
-        bool finished = false;
+        std::jthread reader;
+        std::jthread writer;
+        std::atomic<bool> finished = false;
 
     public:
         Connection() = default;
@@ -821,12 +821,8 @@ private:
           // threads; touching them here would race with their own close().
           toRemote.writeSide.close();
           ctx.TryCancel();
-          if (reader.joinable()) {
-            reader.join();
-          }
-          if (writer.joinable()) {
-            writer.join();
-          }
+          reader = {};
+          writer = {};
           if (stream && !finished) {
             (void)stream->Finish();
           }
@@ -840,15 +836,10 @@ public:
       narFetcher.fetchInto(path, sink);
     }
 
-    ~GrpcStore() override {
-      {
-        std::scoped_lock const lock(infoBatchMutex);
-        infoBatchStop = true;
-      }
-      infoBatchWakeup.notify_one();
-      if (infoBatchWorker.joinable()) {
-        infoBatchWorker.join();
-      }
+    // The worker uses members declared after it, so stop it before they go.
+    ~GrpcStore() override
+    {
+        infoBatchWorker = {};
     }
 
     void addMultipleToStore(
@@ -926,7 +917,7 @@ auto GrpcStore::openConnection() -> ref<RemoteStore::Connection> {
   nixgrpc::growPipe(conn->toRemote);
   nixgrpc::growPipe(conn->fromRemote);
 
-  conn->reader = std::thread([connPtr = &*conn] -> void {
+  conn->reader = std::jthread([connPtr = &*conn] -> void {
     try {
       nixgrpc::pumpFdToStream(connPtr->toRemote.readSide.get(), *connPtr->stream);
     } catch (...) {
@@ -939,7 +930,7 @@ auto GrpcStore::openConnection() -> ref<RemoteStore::Connection> {
     connPtr->toRemote.readSide.close();
   });
 
-  conn->writer = std::thread([this, connPtr = &*conn] -> void {
+  conn->writer = std::jthread([this, connPtr = &*conn] -> void {
     try {
       nixgrpc::pumpStreamToFd(*connPtr->stream, connPtr->fromRemote.writeSide.get());
     } catch (...) {

--- a/src/nar-fetcher.hh
+++ b/src/nar-fetcher.hh
@@ -225,9 +225,7 @@ public:
     {
         for (const auto & session : sessions) {
             session->ctx.TryCancel();
-            if (session->thread.joinable()) {
-                session->thread.join();
-            }
+            session->thread = {};
         }
     }
 
@@ -240,7 +238,7 @@ private:
         grpc::ClientContext ctx;
         std::unique_ptr<grpc::ClientReader<nix::remote::NarFrame>> reader;
         std::vector<std::shared_ptr<NarSpool>> targets;
-        std::thread thread;
+        std::jthread thread;
 
         void run()
         {
@@ -318,7 +316,7 @@ private:
         if (!session->reader) {
             throw nix::Error("failed to open gRPC FetchNars stream to '%s'", authority);
         }
-        session->thread = std::thread([raw = session.get()] -> void { raw->run(); });
+        session->thread = std::jthread([raw = session.get()] -> void { raw->run(); });
         sessions.push_back(std::move(session));
     }
 };

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -62,6 +62,7 @@
 #include "idle.hh"
 #include "import-paths.hh"
 #include "logfmt.hh"
+#include "parse-int.hh"
 #include "path-info-wire.hh"
 #include "metrics.hh"
 #include "nix-compat.hh"
@@ -740,7 +741,11 @@ auto parseOptions(const std::vector<std::string_view> & args) -> Options
         } else if (arg == "--metrics-listen") {
             options.metricsListen = next();
         } else if (arg == "--idle-timeout") {
-            options.idleTimeout = std::chrono::seconds(std::stoul(std::string(next())));
+            auto secs = nixgrpc::parseInt<unsigned>(next());
+            if (!secs) {
+                throw nix::Error("--idle-timeout expects a non-negative integer");
+            }
+            options.idleTimeout = std::chrono::seconds(*secs);
         } else if (arg == "--log-level") {
             options.logLevel = parseLogLevel(next());
         } else {

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -6,6 +6,7 @@
 // handled natively (via a Store opened on the same socket) so `nix copy`
 // avoids the tunnel's per-batch zstd flushes and per-path round trips.
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <csignal>
@@ -830,15 +831,23 @@ try {
     nixgrpc::logLine(
         nixgrpc::LogLevel::info,
         {{"event", "startup"}, {"listen", options.listen}, {"proxy_socket", options.socketPath}});
+    nixgrpc::sdNotify("READY=1");
 
-    if (options.idleTimeout) {
-        while (idle.idleFor() < *options.idleTimeout) {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+    // SIGTERM keeps its default action, so this loop is the daemon's lifetime.
+    auto const watchdog = nixgrpc::sdWatchdogInterval();
+    std::chrono::nanoseconds const tick =
+        watchdog.count() != 0 ? std::min<std::chrono::nanoseconds>(watchdog, std::chrono::seconds(1))
+                              : std::chrono::seconds(1);
+    while (!options.idleTimeout || idle.idleFor() < *options.idleTimeout) {
+        if (watchdog.count() != 0) {
+            nixgrpc::sdNotify("WATCHDOG=1");
         }
-        nixgrpc::logLine(nixgrpc::LogLevel::info, {{"event", "idle_exit"}});
-        constexpr std::chrono::seconds shutdownGrace{5};
-        server->Shutdown(std::chrono::system_clock::now() + shutdownGrace);
+        std::this_thread::sleep_for(tick);
     }
+    nixgrpc::logLine(nixgrpc::LogLevel::info, {{"event", "idle_exit"}});
+    nixgrpc::sdNotify("STOPPING=1");
+    constexpr std::chrono::seconds shutdownGrace{5};
+    server->Shutdown(std::chrono::system_clock::now() + shutdownGrace);
     server->Wait();
     return 0;
 } catch (const std::exception & err) {

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -785,12 +785,21 @@ auto makeServerCredentials(const Options & options) -> std::shared_ptr<grpc::Ser
 
 } // namespace
 
+namespace {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): signal handler.
+volatile std::sig_atomic_t stopSignal = 0;
+} // namespace
+
 auto main(int argc, char ** argv) -> int
 try {
     // Pump threads write to a socket whose peer may already be gone; we want
     // EPIPE, not process death.
     // NOLINTNEXTLINE(misc-include-cleaner): SIGPIPE comes from <csignal>.
     static_cast<void>(std::signal(SIGPIPE, SIG_IGN));
+    // Polled by the main loop so in-flight RPCs get the shutdown grace.
+    for (int const sig : {SIGTERM, SIGINT}) {
+        static_cast<void>(std::signal(sig, [](int) -> void { stopSignal = 1; }));
+    }
 
     // Required before nix::openStore() in the native RPC handlers.
     nix::initLibStore();
@@ -838,18 +847,17 @@ try {
         {{"event", "startup"}, {"listen", options.listen}, {"proxy_socket", options.socketPath}});
     nixgrpc::sdNotify("READY=1");
 
-    // SIGTERM keeps its default action, so this loop is the daemon's lifetime.
     auto const watchdog = nixgrpc::sdWatchdogInterval();
     std::chrono::nanoseconds const tick =
         watchdog.count() != 0 ? std::min<std::chrono::nanoseconds>(watchdog, std::chrono::seconds(1))
                               : std::chrono::seconds(1);
-    while (!options.idleTimeout || idle.idleFor() < *options.idleTimeout) {
+    while (stopSignal == 0 && (!options.idleTimeout || idle.idleFor() < *options.idleTimeout)) {
         if (watchdog.count() != 0) {
             nixgrpc::sdNotify("WATCHDOG=1");
         }
         std::this_thread::sleep_for(tick);
     }
-    nixgrpc::logLine(nixgrpc::LogLevel::info, {{"event", "idle_exit"}});
+    nixgrpc::logLine(nixgrpc::LogLevel::info, {{"event", stopSignal != 0 ? "signal_exit" : "idle_exit"}});
     nixgrpc::sdNotify("STOPPING=1");
     constexpr std::chrono::seconds shutdownGrace{5};
     server->Shutdown(std::chrono::system_clock::now() + shutdownGrace);

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -205,7 +205,7 @@ public:
         }
 
         std::atomic<uint64_t> bytesIn{0};
-        std::thread receiver([&]() -> void {
+        std::jthread receiver([&]() -> void {
             try {
                 bytesIn = nixgrpc::pumpStreamToFd(*stream, sock.get());
             } catch (...) {

--- a/src/parse-int.hh
+++ b/src/parse-int.hh
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <charconv>
+#include <optional>
+#include <string_view>
+#include <system_error>
+
+namespace nixgrpc {
+
+// Whole-string decimal parse. Rejects sign on unsigned, whitespace and
+// trailing junk, unlike std::sto*.
+template<typename T>
+inline auto parseInt(std::string_view str) -> std::optional<T>
+{
+    T value{};
+    const char * first = str.data();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): from_chars wants [first,last).
+    const char * last = first + str.size();
+    auto [end, errc] = std::from_chars(first, last, value);
+    if (str.empty() || errc != std::errc() || end != last) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+} // namespace nixgrpc

--- a/src/socket-activation.hh
+++ b/src/socket-activation.hh
@@ -3,32 +3,52 @@
 // accepts already-connected fds with any ServerCredentials, so we accept()
 // ourselves.
 
+#include <algorithm>
+#include <charconv>
+#include <chrono>
+#include <optional>
+#include <system_error>
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
 #include <fcntl.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <unistd.h>
 
 #include <grpcpp/server_builder.h>
 
 #include <nix/util/environment-variables.hh>
+#include <nix/util/file-descriptor.hh>
 
 namespace nixgrpc {
+
+template<typename T>
+inline auto envInt(const char * name) -> std::optional<T>
+{
+    auto str = nix::getEnv(name).value_or("");
+    T value{};
+    auto [end, errc] = std::from_chars(str.data(), str.data() + str.size(), value);
+    if (str.empty() || errc != std::errc() || end != str.data() + str.size()) {
+        return std::nullopt;
+    }
+    return value;
+}
 
 // sd_listen_fds(3) without libsystemd. Call before starting threads.
 inline auto systemdListenFds() -> std::vector<int>
 {
     constexpr int firstFd = 3;
-    auto pidEnv = nix::getEnv("LISTEN_PID");
-    auto fdsEnv = nix::getEnv("LISTEN_FDS");
-    if (!pidEnv || !fdsEnv || std::stol(*pidEnv) != ::getpid()) {
+    auto count = envInt<int>("LISTEN_FDS");
+    if (!count || envInt<pid_t>("LISTEN_PID") != ::getpid()) {
         return {};
     }
     std::vector<int> fds;
-    for (int sockFd = firstFd; sockFd < firstFd + std::stoi(*fdsEnv); ++sockFd) {
+    for (int sockFd = firstFd; sockFd < firstFd + *count; ++sockFd) {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): C API.
         ::fcntl(sockFd, F_SETFD, FD_CLOEXEC);
         fds.push_back(sockFd);
@@ -38,6 +58,35 @@ inline auto systemdListenFds() -> std::vector<int>
         ::unsetenv(name);
     }
     return fds;
+}
+
+// sd_notify(3) without libsystemd. Best effort, errors are ignored.
+inline void sdNotify(std::string_view state)
+{
+    auto path = nix::getEnv("NOTIFY_SOCKET");
+    if (!path || path->size() < 2 || path->size() >= sizeof(sockaddr_un::sun_path)) {
+        return;
+    }
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::ranges::copy(*path, std::begin(addr.sun_path));
+    if (path->starts_with('@')) {
+        addr.sun_path[0] = '\0'; // abstract namespace
+    }
+    auto addrLen = static_cast<socklen_t>(offsetof(sockaddr_un, sun_path) + path->size());
+    nix::AutoCloseFD const sock(::socket(AF_UNIX, SOCK_DGRAM, 0));
+    if (!sock) {
+        return;
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): sockaddr API.
+    ::sendto(sock.get(), state.data(), state.size(), 0, reinterpret_cast<const sockaddr *>(&addr), addrLen);
+}
+
+// Half of WatchdogSec=, or zero if the watchdog is off.
+inline auto sdWatchdogInterval() -> std::chrono::microseconds
+{
+    auto usec = envInt<uint64_t>("WATCHDOG_USEC");
+    return std::chrono::microseconds(usec.value_or(0) / 2);
 }
 
 // The threads live until process exit. After Server::Shutdown() the acceptor

--- a/src/socket-activation.hh
+++ b/src/socket-activation.hh
@@ -4,10 +4,8 @@
 // ourselves.
 
 #include <algorithm>
-#include <charconv>
 #include <chrono>
 #include <optional>
-#include <system_error>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -25,18 +23,14 @@
 #include <nix/util/environment-variables.hh>
 #include <nix/util/file-descriptor.hh>
 
+#include "parse-int.hh"
+
 namespace nixgrpc {
 
 template<typename T>
 inline auto envInt(const char * name) -> std::optional<T>
 {
-    auto str = nix::getEnv(name).value_or("");
-    T value{};
-    auto [end, errc] = std::from_chars(str.data(), str.data() + str.size(), value);
-    if (str.empty() || errc != std::errc() || end != str.data() + str.size()) {
-        return std::nullopt;
-    }
-    return value;
+    return parseInt<T>(nix::getEnv(name).value_or(""));
 }
 
 // sd_listen_fds(3) without libsystemd. Call before starting threads.

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -181,6 +181,8 @@ pkgs.testers.runNixOSTest {
         machine.require_unit_state("nix-grpc-daemon.service", "inactive")
         out = machine.succeed(f"nix store info --json --store '{store}'")
         assert '"url":"grpc://127.0.0.1:50051' in out, out
+        # Type=notify: only READY=1 from the daemon makes it "active".
+        machine.require_unit_state("nix-grpc-daemon.service", "active")
         machine.wait_until_succeeds("journalctl -u nix-grpc-daemon --since=-1min | grep -q event=idle_exit", timeout=30)
         machine.wait_until_succeeds("systemctl show -P ActiveState nix-grpc-daemon.service | grep -qx inactive", timeout=30)
         machine.succeed(f"nix store info --store '{store}'")


### PR DESCRIPTION
Type=notify lets dependent units and the socket unit see when the gRPC
server actually listens instead of when the process forked, and the
watchdog restarts a wedged daemon. Implemented without libsystemd.
