### PR TITLE
proto: build log lines are bytes, not UTF-8 strings

### DIFF
--- a/proto/nix_remote.proto
+++ b/proto/nix_remote.proto
@@ -67,7 +67,8 @@ message BuildDerivationDone {
 
 message BuildDerivationChunk {
   oneof event {
-    string log_line = 1;
+    // Raw builder stderr, which need not be valid UTF-8.
+    bytes log_line = 1;
     BuildDerivationDone done = 2;
   }
 }
@@ -89,7 +90,8 @@ message BuildPathsDone {
 
 message BuildPathsChunk {
   oneof event {
-    string log_line = 1;
+    // Raw builder stderr, which need not be valid UTF-8.
+    bytes log_line = 1;
     BuildPathsDone done = 2;
   }
 }

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -71,6 +71,17 @@ pkgs.testers.runNixOSTest {
         }
       '';
 
+      # Builders write arbitrary bytes to stderr; the log stream must carry
+      # them.
+      environment.etc."rawlog.nix".text = ''
+        derivation {
+          name = "rawlog-grpc";
+          system = builtins.currentSystem;
+          builder = "/bin/sh";
+          args = [ "-c" "printf 'not utf-8: \\377\\n' >&2; echo rawlog-over-grpc > $out" ];
+        }
+      '';
+
       # Bench corpora as input-addressed outputs: CA paths from `nix store
       # add` are re-hashed on import (RewritingSink), skewing the benchmark.
       environment.etc."blob.nix".text = ''
@@ -202,6 +213,13 @@ pkgs.testers.runNixOSTest {
             "--no-link --print-out-paths"
         ).strip()
         machine.succeed(f"grep -q hello-over-grpc '{p}'")
+
+    with subtest("build whose log is not UTF-8"):
+        p = machine.succeed(
+            f"nix build --store '{store}' --impure -f /etc/rawlog.nix "
+            "--no-link --print-out-paths"
+        ).strip()
+        machine.succeed(f"grep -q rawlog-over-grpc '{p}'")
 
     with subtest("copy from gRPC store to a local scratch store"):
         machine.succeed(


### PR DESCRIPTION
A builder writes arbitrary bytes to stderr, and the daemon relays them line by line as `log_line`. proto3 validates `string` fields as UTF-8 at serialisation, so one stray byte makes the daemon's `Write` fail and the stream stall; the client sees a build that never finishes.

Seen in the wild with a rustc bootstrap build (`wasm32-unknown-wasip1-rustc`): the daemon logged

```
wire_format_lite.cc:578] String field 'nix.remote.BuildDerivationChunk.log_line' contains invalid UTF-8 data when serializing a protocol buffer
```

and the client hung on the stream until it gave up, on every attempt.

`bytes` has the same wire type as `string`, so old and new peers keep interoperating, and the generated C++ accessors are unchanged. The VM test gains a derivation whose log carries a 0xFF byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188pnxV4PbrsAebwxqN7q7t