### PR TITLE
daemon: accept-thread, sigaction, temp-root and batch-callback fixes

### DIFF
--- a/src/grpc-store.cc
+++ b/src/grpc-store.cc
@@ -734,19 +734,27 @@ private:
                 }
                 batch.swap(infoBatch);
             }
+            StorePathSet paths;
+            for (const auto & [path, callback] : batch) {
+                paths.insert(path);
+            }
+            PathInfoMap infos;
             try {
-                StorePathSet paths;
-                for (const auto & [path, callback] : batch) {
-                    paths.insert(path);
-                }
-                auto infos = queryPathInfosNative(paths);
-                for (auto & [path, callback] : batch) {
-                    auto found = infos.find(path);
-                    callback(found == infos.end() ? nullptr : found->second);
-                }
+                infos = queryPathInfosNative(paths);
             } catch (...) {
                 for (auto & [path, callback] : batch) {
                     callback.rethrow();
+                }
+                continue;
+            }
+            // Each callback fires exactly once. One that throws must not
+            // take the worker down or re-fire the others.
+            for (auto & [path, callback] : batch) {
+                auto found = infos.find(path);
+                try {
+                    callback(found == infos.end() ? nullptr : found->second);
+                } catch (...) {
+                    ignoreExceptionExceptInterrupt();
                 }
             }
         }

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <chrono>
 #include <csignal>
+#include <signal.h> // NOLINT(modernize-deprecated-headers): sigaction is POSIX, not in <csignal>
 #include <cstddef>
 #include <initializer_list>
 #include <cstdint>
@@ -794,12 +795,16 @@ auto main(int argc, char ** argv) -> int
 try {
     // Pump threads write to a socket whose peer may already be gone; we want
     // EPIPE, not process death.
-    // NOLINTNEXTLINE(misc-include-cleaner): SIGPIPE comes from <csignal>.
-    static_cast<void>(std::signal(SIGPIPE, SIG_IGN));
+    // NOLINTBEGIN(misc-include-cleaner): darwin's <signal.h> forwards these.
+    struct sigaction act{};
+    act.sa_handler = SIG_IGN;
+    sigaction(SIGPIPE, &act, nullptr);
     // Polled by the main loop so in-flight RPCs get the shutdown grace.
+    act.sa_handler = [](int) -> void { stopSignal = 1; };
     for (int const sig : {SIGTERM, SIGINT}) {
-        static_cast<void>(std::signal(sig, [](int) -> void { stopSignal = 1; }));
+        sigaction(sig, &act, nullptr);
     }
+    // NOLINTEND(misc-include-cleaner)
 
     // Required before nix::openStore() in the native RPC handlers.
     nix::initLibStore();

--- a/src/nix-grpc-daemon.cc
+++ b/src/nix-grpc-daemon.cc
@@ -103,6 +103,12 @@ class NixRemoteService final : public nix::remote::NixRemote::Service
         return nix::ref<nix::Store>(store);
     }
 
+    // nix-daemon keeps temp roots per connection, so writes get their own.
+    auto openScopedStore() -> nix::ref<nix::Store>
+    {
+        return nix::openStore(storeUri);
+    }
+
     // gRPC aborts the process if a handler lets an exception escape.
     template<typename F>
     auto guarded(F && func) -> grpc::Status
@@ -281,7 +287,7 @@ public:
             }
             auto const peer = context->peer();
             auto const start = std::chrono::steady_clock::now();
-            auto localStore = getStore();
+            auto localStore = openScopedStore();
 
             nix::remote::AddMultipleChunk first;
             if (!reader->Read(&first)) {

--- a/src/socket-activation.hh
+++ b/src/socket-activation.hh
@@ -83,8 +83,9 @@ inline auto sdWatchdogInterval() -> std::chrono::microseconds
     return std::chrono::microseconds(usec.value_or(0) / 2);
 }
 
-// The threads live until process exit. After Server::Shutdown() the acceptor
-// drops new connections itself.
+// The threads live until process exit: the listen fds belong to systemd and
+// must not be shut down. After Server::Shutdown() the acceptor drops new
+// connections itself.
 inline void
 acceptInto(const std::vector<int> & listenFds, const std::shared_ptr<grpc::experimental::ExternalConnectionAcceptor> & acceptor)
 {
@@ -94,7 +95,10 @@ acceptInto(const std::vector<int> & listenFds, const std::shared_ptr<grpc::exper
                 // No accept4 on macOS.
                 int const conn = ::accept(listenFd, nullptr, nullptr);
                 if (conn < 0) {
-                    continue;
+                    if (errno == EINTR || errno == ECONNABORTED || errno == EMFILE || errno == ENFILE) {
+                        continue;
+                    }
+                    return;
                 }
                 // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): C API.
                 ::fcntl(conn, F_SETFD, FD_CLOEXEC);

--- a/tests/nixos-test.nix
+++ b/tests/nixos-test.nix
@@ -423,6 +423,10 @@ pkgs.testers.runNixOSTest {
         )
         machine.succeed(f"test -e '{up}'")
 
+    with subtest("uploaded paths are not pinned by the proxy after the RPC returns"):
+        machine.succeed(f"nix-store --delete '{up}'")
+        machine.fail(f"test -e '{up}'")
+
     with subtest("many small paths round-trip (native AddMultipleToStore / NarsFromPaths)"):
         import time
 


### PR DESCRIPTION
Independent of the farm work, can merge first.

- stop accept threads on real errors instead of spinning
- install signal handlers with sigaction
- do not pin uploaded paths for the process lifetime (regression test in nixos-test)
- fire batched path-info callbacks exactly once